### PR TITLE
Fix hero font size and prevent bot PR loop

### DIFF
--- a/.github/workflows/contributor-tracker.yml
+++ b/.github/workflows/contributor-tracker.yml
@@ -29,7 +29,9 @@ on:
 
 jobs:
   track-contributor:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    if: |
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
 
     permissions:

--- a/site-src/assets/styles.css
+++ b/site-src/assets/styles.css
@@ -134,7 +134,7 @@ img {
 
 .hero h1 {
   font-family: 'Space Grotesk', sans-serif;
-  font-size: clamp(2.6rem, 4vw, 4rem);
+  font-size: clamp(2rem, 3vw, 3rem);
   line-height: 1.05;
   margin: 0 0 1rem;
 }


### PR DESCRIPTION
- Reduce hero h1 font size for longer tagline
- Skip contributor tracking when PR author is github-actions[bot]