### PR TITLE
Fix tracker force-push data loss and correct commit count

### DIFF
--- a/.github/workflows/contributor-tracker.yml
+++ b/.github/workflows/contributor-tracker.yml
@@ -52,6 +52,19 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
+      - name: Use accumulated contributors.yaml if available
+        run: |
+          # If contributor-update/auto exists, use its contributors.yaml
+          # to preserve accumulated updates from previous unmerged runs.
+          # Without this, each force-push would overwrite previous updates.
+          if git fetch origin contributor-update/auto 2>/dev/null; then
+            git checkout origin/contributor-update/auto -- contributors.yaml 2>/dev/null && \
+              echo "Using accumulated contributors.yaml from contributor-update/auto" || \
+              echo "Branch exists but contributors.yaml checkout failed, using main"
+          else
+            echo "No existing contributor-update/auto branch, starting from main"
+          fi
+
       - name: Get PR info and analyze contributions
         id: analyze
         env:

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -23,7 +23,7 @@ maintainers:
     citations_added: 9
     pr: 49
   total_citations: 17
-  commits: 21
+  commits: 53
 trusted: []
 contributors:
 - github: FreeGym


### PR DESCRIPTION
The contributor-tracker was starting from main's contributors.yaml on every run, so force-pushing to contributor-update/auto would overwrite previous unmerged updates. Now fetches the accumulated contributors.yaml from the existing branch first.

Also corrects mutant1643 commit count from 21 to 53 (actual).