### PR TITLE
Exclude ScienceDirect and github-actions[bot] from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -46,6 +46,8 @@ jobs:
             --exclude "^https://x.com"
             --exclude "^https://www\\.efsa\\.europa\\.eu/"
             --exclude "^https://doi\\.org/10\\.2903/j\\.efsa\\.2012\\.2557"
+            --exclude "^https://www\\.sciencedirect\\.com"
+            --exclude "^https://github\\.com/github-actions\\[bot\\]"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
ScienceDirect returns 403 to bot user-agents; links are valid. github-actions[bot] is not a real GitHub profile URL.