### PR TITLE
Add GH_TOKEN to Update contributors step

### DIFF
--- a/.github/workflows/contributor-tracker.yml
+++ b/.github/workflows/contributor-tracker.yml
@@ -209,6 +209,8 @@ jobs:
           PYTHON_SCRIPT
 
       - name: Update contributors.yaml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python << 'PYTHON_SCRIPT'
           import yaml


### PR DESCRIPTION
The get_absolute_commit_count function calls gh api, which needs authentication via GH_TOKEN.  Without it, the API call fails silently and falls back to incremental counting.