### PR TITLE
Exclude MDPI and OUP Academic from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -47,6 +47,8 @@ jobs:
             --exclude "^https://www\\.efsa\\.europa\\.eu/"
             --exclude "^https://doi\\.org/10\\.2903/j\\.efsa\\.2012\\.2557"
             --exclude "^https://www\\.sciencedirect\\.com"
+            --exclude "^https://www\\.mdpi\\.com"
+            --exclude "^https://academic\\.oup\\.com"
             --exclude "^https://github\\.com/github-actions\\[bot\\]"
             --timeout 30
             '**/*.md'


### PR DESCRIPTION
MDPI and OUP Academic return 403 to automated requests from GitHub Actions, same as ScienceDirect. Adding them to the exclusion list to stop false-positive failures on every push.