### PR TITLE
Remove core/governance from contributor cards

### DIFF
--- a/.github/scripts/generate_cards.py
+++ b/.github/scripts/generate_cards.py
@@ -360,8 +360,7 @@ def main():
 
     # Maintainers
     for m in data.get('maintainers', []):
-        # Combine topics and specialty fields
-        topics = list(m.get('topics', []) or []) + list(m.get('specialty', []) or [])
+        topics = list(m.get('topics', []) or [])
         all_contributors.append({
             'github': m.get('github', ''),
             'name': m.get('name', m.get('github', '')),

--- a/.github/scripts/generate_site.py
+++ b/.github/scripts/generate_site.py
@@ -30,8 +30,6 @@ TOPIC_LABELS = {
     'supplements': 'Supplements',
     'recovery': 'Recovery',
     'biomechanics': 'Biomechanics',
-    'core': 'Core',
-    'governance': 'Governance',
 }
 
 TOPIC_ORDER = [
@@ -42,8 +40,6 @@ TOPIC_ORDER = [
     'supplements',
     'recovery',
     'biomechanics',
-    'core',
-    'governance',
 ]
 
 
@@ -67,7 +63,7 @@ def collect_profiles(data):
     def add_profile(entry, role):
         github = entry.get('github', '')
         name = entry.get('name') or github
-        topics = entry.get('topics', []) or entry.get('specialty', []) or []
+        topics = entry.get('topics', []) or []
         contributions = entry.get('contributions', []) or []
         citations = entry.get('total_citations', 0)
         commits = entry.get('commits', 0)

--- a/contributors.yaml
+++ b/contributors.yaml
@@ -2,9 +2,6 @@ maintainers:
 - github: mutant1643
   name: Abhinav
   joined: 2026-01
-  specialty:
-  - core
-  - governance
   topics:
   - nutrition
   last_active: 2026-02


### PR DESCRIPTION
## Summary
- Removed the `specialty` field from `contributors.yaml` (contained `core` and `governance` for Abhinav)
- Removed `core` and `governance` from topic labels and topic order in `generate_site.py`
- Stopped merging `specialty` into `topics` in `generate_cards.py`
- Stopped falling back to `specialty` in `generate_site.py`

Contributor cards should only show content-area topics (nutrition, exercise, etc.), not organizational roles.

## Test plan
- [x] Verify cards regenerate without core/governance badges after merge
- [x] Verify the profiles site no longer lists core/governance as filter options