### PR TITLE
Fix link checker: Exclude 403-blocked DOI prefixes

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -52,6 +52,12 @@ jobs:
             --exclude "^https://www\\.sciencedirect\\.com"
             --exclude "^https://www\\.mdpi\\.com"
             --exclude "^https://academic\\.oup\\.com"
+            --exclude "^https://doi\\.org/10\\.3390/"
+            --exclude "^https://doi\\.org/10\\.1093/"
+            --exclude "^https://doi\\.org/10\\.14814/"
+            --exclude "^https://doi\\.org/10\\.1113/"
+            --exclude "^https://doi\\.org/10\\.1073/"
+            --exclude "^https://doi\\.org/10\\.1152/"
             --exclude "^https://github\\.com/github-actions\\[bot\\]"
             --timeout 30
             '**/*.md'


### PR DESCRIPTION
Fixes link checker false positives from journal sites that block GitHub Actions runners.

## Problem
Link checker was failing on 9 valid DOIs because these journal sites return 403 Forbidden to automated crawlers:
- MDPI/Nutrients (10.3390)
- Oxford University Press (10.1093)
- Physiological Reports (10.14814)
- Journal of Physiology (10.1113)
- PNAS (10.1073)
- Journal of Applied Physiology (10.1152)

## Solution
Added DOI prefix exclusions. Domain exclusions were already in place but ineffective because the link checker validates DOI URLs before they redirect.

## Verification
All excluded DOIs were manually verified as working during exhaustive citation verification of protein-supplements-vs-whole-food.md article.