### PR TITLE
fix: exclude flaky DOI timeout in link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -48,6 +48,7 @@ jobs:
             --exclude "^https://doi\\.org/10\\.2903/j\\.efsa\\.2012\\.2557"
             --exclude "^https://doi\\.org/10\\.7326/0003-4819-138-6-200303180-00009"
             --exclude "^https://doi\\.org/10\\.1155/2016/9104792"
+            --exclude "^https://doi\\.org/10\\.1017/S0007114520002238"
             --exclude "^https://doi\\.org/10\\.1093/ndt/gfz115"
             --exclude "^https://www\\.sciencedirect\\.com"
             --exclude "^https://www\\.mdpi\\.com"


### PR DESCRIPTION
## Summary\n- add an explicit Lychee exclude for https://doi.org/10.1017/S0007114520002238\n\n## Why\nThe DOI resolver intermittently returns gateway timeout in GitHub Actions, causing false-negative link-check failures.\n\n## Scope\n- one workflow line added\n- no content or citation text changed