### PR TITLE
Add link checker exclusions for Wiley, SAGE, Taylor & Francis

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -61,6 +61,12 @@ jobs:
             --exclude "^https://doi\\.org/10\\.1152/"
             --exclude "^https://github\\.com/github-actions\\[bot\\]"
             --exclude "^https://faseb\\.onlinelibrary\\.wiley\\.com"
+            --exclude "^https://onlinelibrary\\.wiley\\.com"
+            --exclude "^https://journals\\.sagepub\\.com"
+            --exclude "^https://www\\.tandfonline\\.com"
+            --exclude "^https://doi\\.org/10\\.1177/"
+            --exclude "^https://doi\\.org/10\\.1186/"
+            --exclude "^https://doi\\.org/10\\.1002/"
             --exclude "^https://jamanetwork\\.com"
             --exclude "^https://ajcn\\.nutrition\\.org"
             --timeout 30


### PR DESCRIPTION
These publishers block GitHub Actions runners with 403 Forbidden. Adding domain-level exclusions prevents future failures when articles cite papers from these sources.

Excludes:
- onlinelibrary.wiley.com
- journals.sagepub.com  
- www.tandfonline.com
- DOI prefixes: 10.1177/, 10.1186/, 10.1002/