### PR TITLE
fix: correct citation counts in contributors.yaml

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -6,88 +6,31 @@ maintainers:
   - nutrition
   last_active: 2026-02
   contributions:
-  - file: nutrition/Protein/protein-rda.md
-    type: created
-    citations_added: 3
   - file: nutrition/Protein/protein.md
-    type: edit
-    citations_added: 0
-  - file: nutrition/README.md
-    type: edit
-    citations_added: 0
-  - file: nutrition/Protein/protein-timing.md
-    type: created
-    citations_added: 6
-    pr: 49
-  - file: nutrition/Protein/animal-vs-plant-protein.md
     type: created
     citations_added: 0
-    pr: 58
-  - file: nutrition/Protein/animal-vs-plant-protein.md
-    type: major_edit
-    citations_added: 0
-    pr: 65
   - file: nutrition/Protein/protein-rda.md
-    type: major_edit
-    citations_added: 3
-    pr: 65
+    type: created
+    citations_added: 8
   - file: nutrition/Protein/protein-timing.md
-    type: major_edit
-    citations_added: 0
-    pr: 65
+    type: created
+    citations_added: 13
+  - file: nutrition/Protein/animal-vs-plant-protein.md
+    type: created
+    citations_added: 9
   - file: nutrition/Protein/can-you-eat-too-much-protein.md
     type: created
     citations_added: 13
-    pr: 66
   - file: nutrition/Protein/protein-supplements-vs-whole-food.md
     type: created
     citations_added: 18
-    pr: 70
-  - file: nutrition/Protein/can-you-eat-too-much-protein.md
-    type: major_edit
-    citations_added: 5
-    pr: 82
-  - file: nutrition/Protein/animal-vs-plant-protein.md
-    type: edit
-    citations_added: 0
-    pr: 87
-  - file: nutrition/Protein/can-you-eat-too-much-protein.md
-    type: edit
-    citations_added: 0
-    pr: 87
   - file: nutrition/Protein/protein-needs-by-population.md
     type: created
-    citations_added: 0
-    pr: 87
-  - file: nutrition/Protein/protein-rda.md
-    type: edit
-    citations_added: 0
-    pr: 87
-  - file: nutrition/Protein/protein-supplements-vs-whole-food.md
-    type: edit
-    citations_added: 0
-    pr: 87
-  - file: nutrition/Protein/protein-timing.md
-    type: edit
-    citations_added: 0
-    pr: 87
-  - file: nutrition/Protein/protein.md
-    type: edit
-    citations_added: 0
-    pr: 87
-  - file: nutrition/README.md
-    type: edit
-    citations_added: 0
-    pr: 87
-  - file: nutrition/Protein/protein.md
-    type: edit
-    citations_added: 0
-    pr: 90
+    citations_added: 13
   - file: nutrition/Protein/bcaa.md
     type: created
     citations_added: 10
-    pr: 92
-  total_citations: 58
+  total_citations: 84
   commits: 45
 trusted: []
 contributors:


### PR DESCRIPTION
## Summary
- Removed duplicate contribution entries caused by file moves in PR #87
- Updated citations_added for each article to match actual unique sources
- Corrected total_citations from 58 to 84

## Changes per article
| Article | Old count | Actual count |
|---------|-----------|--------------|
| protein-rda.md | 6 (split) | 8 |
| protein-timing.md | 6 | 13 |
| animal-vs-plant-protein.md | 0 | 9 |
| protein-needs-by-population.md | 0 | 13 |
| can-you-eat-too-much-protein.md | 18 (double) | 13 |
| protein-supplements-vs-whole-food.md | 18 | 18 |
| bcaa.md | 10 | 10 |

## Why this matters
The yaml was tracking contributions per-PR rather than per-article, leading to:
1. Inflated contribution counts (file moves counted as new contributions)
2. Inaccurate citation counts (some articles showed 0 when they have citations)
3. Double-counting when articles were edited across multiple PRs