### PR TITLE
Add link checker exclusions for ADA and T&F DOI prefixes

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -67,6 +67,8 @@ jobs:
             --exclude "^https://doi\\.org/10\\.1177/"
             --exclude "^https://doi\\.org/10\\.1186/"
             --exclude "^https://doi\\.org/10\\.1002/"
+            --exclude "^https://doi\\.org/10\\.1080/"
+            --exclude "^https://doi\\.org/10\\.2337/"
             --exclude "^https://jamanetwork\\.com"
             --exclude "^https://ajcn\\.nutrition\\.org"
             --timeout 30


### PR DESCRIPTION
## Summary
- Adds DOI prefix exclusions for publishers that block GitHub runners with 403:
  - 10.1080 (Taylor & Francis)
  - 10.2337 (American Diabetes Association)

## Context
The link checker failed after merging PR #104 because these two DOIs return 403 to automated crawlers. The links are valid - the publishers just block bots.