### PR TITLE
Fix link checker false positives from publisher blocks

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -71,6 +71,9 @@ jobs:
             --exclude "^https://doi\\.org/10\\.2337/"
             --exclude "^https://jamanetwork\\.com"
             --exclude "^https://ajcn\\.nutrition\\.org"
+            --exclude "^https://www\\.nejm\\.org"
+            --exclude "^https://www\\.ahajournals\\.org"
+            --exclude "^https://www\\.cochranelibrary\\.com"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
## Summary

Add exclusions for three publishers that block GitHub Actions with false positive errors:

- **NEJM** (403 Forbidden)
- **AHA Journals** (403 Forbidden)  
- **Cochrane Library** (412 Precondition Failed)

## Why this is needed

These sites block automated crawlers but the links are valid. This follows the established pattern in the link checker config for other publishers (ScienceDirect, MDPI, OUP, Wiley, SAGE, Taylor & Francis).

## Test plan

- [x] Pattern matches existing publisher exclusions
- [x] Will resolve failing checks on main branch