### PR TITLE
Fix link checker for JCEM DOI prefix

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -55,6 +55,7 @@ jobs:
             --exclude "^https://academic\\.oup\\.com"
             --exclude "^https://doi\\.org/10\\.3390/"
             --exclude "^https://doi\\.org/10\\.1093/"
+            --exclude "^https://doi\\.org/10\\.1210/"
             --exclude "^https://doi\\.org/10\\.14814/"
             --exclude "^https://doi\\.org/10\\.1113/"
             --exclude "^https://doi\\.org/10\\.1073/"


### PR DESCRIPTION
Adds exclusion for DOI prefix 10.1210 (Journal of Clinical Endocrinology & Metabolism). This publisher blocks GitHub Actions runners with 403 errors, causing false positives in the link checker.