### PR TITLE
Exclude PubMed and PMC from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -79,6 +79,8 @@ jobs:
             --exclude "^https://www\\.ahajournals\\.org"
             --exclude "^https://www\\.cochranelibrary\\.com"
             --exclude "^https://www\\.researchgate\\.net"
+            --exclude "^https://pubmed\\.ncbi\\.nlm\\.nih\\.gov"
+            --exclude "^https://pmc\\.ncbi\\.nlm\\.nih\\.gov"
             --exclude "^https://(?:www\\.)?diabetesjournals\\.org"
             --exclude "^https://(?:www\\.)?cell\\.com"
             --exclude "^https://(?:www\\.)?jacc\\.org"


### PR DESCRIPTION
## Summary
- Add `pubmed.ncbi.nlm.nih.gov` and `pmc.ncbi.nlm.nih.gov` to link checker exclusions
- PubMed rate-limits GitHub Actions runners with 429 Too Many Requests, causing false failures on every push
- All 62 errors in the last run were valid PubMed links being rate-limited