### PR TITLE
Format large profile stats with separators

### DIFF
--- a/.github/scripts/generate_cards.py
+++ b/.github/scripts/generate_cards.py
@@ -43,6 +43,14 @@ TOPIC_LABELS = {
 }
 
 
+def format_number(value):
+    """Format integers with thousands separators for display."""
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def get_png_size(path):
     """Return (width, height) for a PNG image."""
     with open(path, 'rb') as f:
@@ -189,9 +197,11 @@ def generate_card(
 
     # Format contributions as a simple count
     contributions_count = len(files) if files else 0
-    contributions_display = f'{contributions_count}'
+    contributions_display = format_number(contributions_count)
 
     commits_value = commits if commits is not None else 0
+    citations_display = format_number(citations if citations is not None else 0)
+    commits_display = format_number(commits_value)
     active_recent = is_active_recent(last_active)
 
     # Type sizes
@@ -341,10 +351,10 @@ def generate_card(
   <text x="{right_x:.2f}" y="{right1_value_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{value_size:.2f}" fill="white">{last_active}</text>
 
   <text x="{right_x:.2f}" y="{right2_label_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{label_size:.2f}" fill="#8a8a8a">CITATIONS</text>
-  <text x="{right_x:.2f}" y="{right2_value_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{value_size:.2f}" fill="white">{citations}</text>
+  <text x="{right_x:.2f}" y="{right2_value_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{value_size:.2f}" fill="white">{citations_display}</text>
 
   <text x="{right_x:.2f}" y="{right3_label_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{label_size:.2f}" fill="#8a8a8a">COMMITS</text>
-  <text x="{right_x:.2f}" y="{right3_value_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{value_size:.2f}" fill="white">{commits_value}</text>
+  <text x="{right_x:.2f}" y="{right3_value_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{value_size:.2f}" fill="white">{commits_display}</text>
 
   <text x="{right_x:.2f}" y="{right4_label_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{label_size:.2f}" fill="#8a8a8a">CONTRIBUTIONS</text>
   <text x="{right_x:.2f}" y="{right4_value_y:.2f}" font-family="system-ui, -apple-system, sans-serif" font-size="{value_size:.2f}" fill="white">{contributions_display}</text>

--- a/.github/scripts/generate_site.py
+++ b/.github/scripts/generate_site.py
@@ -78,6 +78,13 @@ def esc(value):
     return html.escape(str(value))
 
 
+def format_number(value):
+    try:
+        return f"{int(value):,}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def read_data():
     with open(REPO_ROOT / 'contributors.yaml', 'r', encoding='utf-8') as f:
         return yaml.safe_load(f)
@@ -183,9 +190,9 @@ def render_profile_card(profile):
         <span class="role-badge {role_class(profile['role'])}">{role_badge(profile['role'])}</span>
       </div>
       <div class="stats">
-        <div class="stat"><span>Citations</span><strong>{profile['citations']}</strong></div>
-        <div class="stat"><span>Contributions</span><strong>{contributions}</strong></div>
-        <div class="stat"><span>Commits</span><strong>{profile['commits']}</strong></div>
+        <div class="stat"><span>Citations</span><strong>{format_number(profile['citations'])}</strong></div>
+        <div class="stat"><span>Contributions</span><strong>{format_number(contributions)}</strong></div>
+        <div class="stat"><span>Commits</span><strong>{format_number(profile['commits'])}</strong></div>
         <div class="stat"><span>Last Active</span><strong>{esc(profile['last_active'])}</strong></div>
       </div>
       <div class="topic-row">{render_topics(profile['topics'])}</div>
@@ -239,9 +246,9 @@ def render_index(profiles, topics, stats):
         </div>
       </div>
       <div class="hero-panel">
-        <div class="stat"><span>Verified profiles</span><strong>{stats['verified']}</strong></div>
-        <div class="stat"><span>Total citations</span><strong>{stats['citations']}</strong></div>
-        <div class="stat"><span>Active topics</span><strong>{stats['topics']}</strong></div>
+        <div class="stat"><span>Verified profiles</span><strong>{format_number(stats['verified'])}</strong></div>
+        <div class="stat"><span>Total citations</span><strong>{format_number(stats['citations'])}</strong></div>
+        <div class="stat"><span>Active topics</span><strong>{format_number(stats['topics'])}</strong></div>
       </div>
     </section>
 
@@ -289,7 +296,7 @@ def render_contributions(contributions):
   <a href="{REPO_URL}/blob/main/{file_path}">{esc(file_name)}</a>
   <div class="contribution-meta">
     <span>Type: {esc(ctype)}</span>
-    <span>Citations added: {citations_added}</span>
+    <span>Citations added: {format_number(citations_added)}</span>
     <span>File: {esc(file_path)}{pr_link}</span>
   </div>
 </div>'''
@@ -336,9 +343,9 @@ def render_profile(profile):
         <div class="role-badge {role_class(profile['role'])}" style="margin-top: 0.75rem; display: inline-flex;">{role_badge(profile['role'])}</div>
         <div class="topic-row">{render_topics(profile['topics'])}</div>
         <div class="stats">
-          <div class="stat"><span>Citations</span><strong>{profile['citations']}</strong></div>
-          <div class="stat"><span>Contributions</span><strong>{contributions}</strong></div>
-          <div class="stat"><span>Commits</span><strong>{profile['commits']}</strong></div>
+          <div class="stat"><span>Citations</span><strong>{format_number(profile['citations'])}</strong></div>
+          <div class="stat"><span>Contributions</span><strong>{format_number(contributions)}</strong></div>
+          <div class="stat"><span>Commits</span><strong>{format_number(profile['commits'])}</strong></div>
           <div class="stat"><span>Last Active</span><strong>{esc(profile['last_active'])}</strong></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- format profile stats with thousands separators in the card generator and contributor site generator
- keep the underlying calculations unchanged while rendering large numbers like 1113 as 1,113

## Notes
- verified against contributors.yaml: mutant1643 still resolves to 1,113 citations, 76 commits, and 86 contributions