### PR TITLE
Fix link checker timeout and contributor tracker for fork PRs

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -69,6 +69,7 @@ jobs:
             --exclude "^https://(?:www\\.)?diabetesjournals\\.org"
             --exclude "^https://(?:www\\.)?cell\\.com"
             --exclude "^https://(?:www\\.)?jacc\\.org"
+            --exclude "^https://eprints\\.gla\\.ac\\.uk"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
Two fixes:

1. **Exclude Glasgow eprints from link checker** - University repository server (eprints.gla.ac.uk) times out for automated crawlers, causing false positive CI failures on Womens-Health articles.

2. **Use pull_request_target for contributor tracker** - The `pull_request` trigger gives `GITHUB_TOKEN` read-only access for fork PRs, which caused the tracker to fail on PR #187 (Thestrongdoc). Switching to `pull_request_target` runs the workflow in the base repo context with full write access. This is safe because the workflow only reads PR diffs via the GitHub API and never executes fork code.