### PR TITLE
Exclude National Academies read pages

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -59,6 +59,8 @@ jobs:
             --exclude "^https://www\\.ahajournals\\.org"
             --exclude "^https://www\\.cochranelibrary\\.com"
             --exclude "^https://www\\.researchgate\\.net"
+            --exclude "^https://(?:www\\.)?nationalacademies\\.org/read/"
+            --exclude "^https://nap\\.nationalacademies\\.org/read/"
             --exclude "^https://(?:www\\.)?link\\.springer\\.com"
             --exclude "^https://findresearcher\\.sdu\\.dk"
             --exclude "^https://pubmed\\.ncbi\\.nlm\\.nih\\.gov"


### PR DESCRIPTION
Summary:
- Exclude National Academies and NAP read-page URLs that returned 503 from GitHub Actions.

Test:
- Parsed link-checker.yml with PyYAML.