### PR TITLE
Show verified communicators on the homepage

### DIFF
--- a/.github/scripts/generate_site.py
+++ b/.github/scripts/generate_site.py
@@ -254,7 +254,33 @@ def render_profile_card(profile):
     '''
 
 
-def render_index(profiles, topics, stats):
+def render_communicator_homepage_card(comm):
+    """Compact homepage card for a communicator. Reuses existing CSS classes."""
+    topics_attr = ','.join(comm['topics'])
+    topic_count = len(comm['topics'])
+
+    return f'''
+    <article class="profile-card reveal" data-profile data-name="{esc(comm['name'])}" data-handle="{esc(comm['github'])}" data-topics="{esc(topics_attr)}">
+      <div class="card-top">
+        <img class="avatar" src="https://github.com/{esc(comm['github'])}.png?size=200" alt="{esc(comm['name'])} avatar">
+        <div class="identity">
+          <h3>{esc(comm['name'])}</h3>
+          <p>@{esc(comm['github'])}</p>
+        </div>
+        <span class="role-badge verified">Verified Communicator</span>
+      </div>
+      <div class="stats">
+        <div class="stat"><span>Verified Since</span><strong>{esc(format_verified_since(comm['verified_since']))}</strong></div>
+        <div class="stat"><span>Topics</span><strong>{format_number(topic_count)}</strong></div>
+        <div class="stat"><span>Verified By</span><strong>FreeGym</strong></div>
+      </div>
+      <div class="topic-row">{render_topics(comm['topics'])}</div>
+      <a class="card-link" href="communicators/{esc(comm['github'])}/">View profile</a>
+    </article>
+    '''
+
+
+def render_index(profiles, communicators, topics, stats):
     topic_buttons = ['<button class="filter-chip active" data-topic="all">All topics</button>']
     for key in topics:
         topic_buttons.append(
@@ -262,6 +288,20 @@ def render_index(profiles, topics, stats):
         )
 
     cards_html = '\n'.join(render_profile_card(p) for p in profiles)
+
+    if communicators:
+        communicator_cards_html = '\n'.join(render_communicator_homepage_card(c) for c in communicators)
+        communicator_section = f'''
+    <section class="reveal" style="margin-top: 4rem;">
+      <h2 style="margin-bottom: 0.5rem;">Verified Communicators</h2>
+      <p style="opacity: 0.7; margin-bottom: 1.5rem;">Vetted public communicators of FreeGym Wiki articles.</p>
+      <section class="profile-grid">
+        {communicator_cards_html}
+      </section>
+    </section>
+'''
+    else:
+        communicator_section = ''
 
     return f'''<!doctype html>
 <html lang="en">
@@ -318,7 +358,7 @@ def render_index(profiles, topics, stats):
     <section class="profile-grid">
       {cards_html}
     </section>
-
+{communicator_section}
     <div class="footer">Generated from contributors.yaml. Last updated {stats['updated']}.</div>
   </main>
 
@@ -558,7 +598,7 @@ def main():
     # Ensure GitHub Pages serves all files.
     write_file(SITE_DIR / '.nojekyll', '')
 
-    index_html = render_index(profiles, topics, stats)
+    index_html = render_index(profiles, communicators, topics, stats)
     write_file(SITE_DIR / 'index.html', index_html)
 
     for profile in profiles:


### PR DESCRIPTION
## Summary

Follow-up to #205. Communicators currently render at `/communicators/<handle>/` but don't appear on the homepage at `/`, making them undiscoverable without a direct link.

This PR adds a **Verified Communicators** section below the contributor grid on the homepage. Each homepage card shows avatar, name, "Verified Communicator" badge, verified-since date, topic count, topic chips, and a link to the full profile.

## Files

- `.github/scripts/generate_site.py` (+43 / −3) — adds `render_communicator_homepage_card()`; `render_index()` now accepts a `communicators` list and conditionally renders a section beneath the contributor grid

## Visual / CSS

Reuses existing classes only: `.profile-card`, `.role-badge.verified`, `.stats`, `.stat`, `.topic-row`, `.chip`, `.card-link`. No styles.css edits.

## Behavior

Section renders only when the `communicators:` block in `contributors.yaml` is non-empty. Backwards-compatible — homepage layout unchanged when no communicators exist.

## Test plan

- [x] Local: regenerated site, confirmed Anshul's card appears in the new section with link to `/communicators/anshulsadhale02/`
- [x] Existing 3 contributor cards still render unchanged in their grid
- [ ] Post-merge: verify https://freegym.github.io/FreeGym-Wiki/ now shows the section
- [ ] Post-merge: run `gh workflow run card-refresh.yml` (still pending from #205) so og:image URLs resolve