### PR TITLE
Add "Verified Contributors" header for homepage symmetry

### DIFF
--- a/.github/scripts/generate_site.py
+++ b/.github/scripts/generate_site.py
@@ -355,8 +355,12 @@ def render_index(profiles, communicators, topics, stats):
       <div class="results-bar" data-results>0 profiles</div>
     </section>
 
-    <section class="profile-grid">
-      {cards_html}
+    <section class="reveal" style="margin-top: 1rem;">
+      <h2 style="margin-bottom: 0.5rem;">Verified Contributors</h2>
+      <p style="opacity: 0.7; margin-bottom: 1.5rem;">Authors and editors of FreeGym Wiki articles.</p>
+      <section class="profile-grid">
+        {cards_html}
+      </section>
     </section>
 {communicator_section}
     <div class="footer">Generated from contributors.yaml. Last updated {stats['updated']}.</div>


### PR DESCRIPTION
## Summary

Follow-up to #206. The homepage now has a labeled "Verified Communicators" section, but the contributor cards above have no header — making the two groups read asymmetrically.

This PR adds a parallel **"Verified Contributors"** header above the contributor grid so both groups have the same visual structure.

## Files

- `.github/scripts/generate_site.py` (+6 / −2) — wraps the existing `<section class="profile-grid">` in a labeled section with h2 + description

## Behavior

- Title: **Verified Contributors**
- Description: *Authors and editors of FreeGym Wiki articles.*
- Same visual treatment (h2 + p + section.profile-grid wrapper) as the communicators section header
- No CSS changes — reuses existing styles

## Note on history

This is a clean re-application of a commit that didn't make it into #206 due to a PR-sync timing race when the merge happened concurrently with the second commit being pushed.

## Test plan

- [x] Local: regenerated site, confirmed both "Verified Contributors" and "Verified Communicators" render with parallel structure
- [ ] Post-merge: visit https://freegym.github.io/FreeGym-Wiki/ to confirm both headers appear above their respective grids