### PR TITLE
Add publisher link exclusions

### DIFF
--- a/.github/workflows/contributor-tracker.yml
+++ b/.github/workflows/contributor-tracker.yml
@@ -262,6 +262,8 @@ jobs:
                   r'https?://publications\.aap\.org/[^\s\)]+',
                   r'https?://onlinecjc\.ca/article/[^\s\)]+',
                   r'https?://(?:www\.)?lipidjournal\.com/article/[^\s\)]+',
+                  r'https?://journals\.lww\.com/[^\s\)]+',
+                  r'https?://psychiatryonline\.org/doi/[^\s\)]+',
               ]
 
               publisher_urls = set()

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -88,6 +88,8 @@ jobs:
             --exclude "^https://publications\\.aap\\.org"
             --exclude "^https://onlinecjc\\.ca"
             --exclude "^https://www\\.lipidjournal\\.com"
+            --exclude "^https://journals\\.lww\\.com"
+            --exclude "^https://psychiatryonline\\.org"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
## Summary
- Exclude LWW and PsychiatryOnline citation URLs from link checking
- Keep both domains counted by the contributor citation URL patterns

## Validation
- `git diff --cached --check`
- Confirmed the two failing URLs from the latest run match the new exclude patterns