### PR TITLE
Exclude timed out funding link

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -90,6 +90,7 @@ jobs:
             --exclude "^https://www\\.lipidjournal\\.com"
             --exclude "^https://journals\\.lww\\.com"
             --exclude "^https://psychiatryonline\\.org"
+            --exclude "^https://profith\\.ugr\\.es"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
## Summary
- Exclude the `profith.ugr.es` funding-statement URL from link checking

## Validation
- `git diff --cached --check`
- Confirmed the timed-out URL from the latest run matches the new exclude pattern