### PR TITLE
Add Mansafabepari as verified communicator

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -963,3 +963,16 @@ communicators:
   - pharmacology
   - wearables
   - musculoskeletal-health
+- github: Mansafabepari
+  name: Mansafa Bepari
+  verified_since: 2026-06
+  verified_topics:
+  - exercise-physiology
+  - nutrition
+  - cardiology
+  - biomarkers
+  - Womens-Health
+  - sleep
+  - pharmacology
+  - wearables
+  - musculoskeletal-health


### PR DESCRIPTION
Adds Mansafabepari as a verified communicator in contributors.yaml, including Women's Health in the verified topics. No article content changes.