### PR TITLE
Show all communicator card topics

### DIFF
--- a/.github/scripts/generate_cards.py
+++ b/.github/scripts/generate_cards.py
@@ -530,7 +530,7 @@ def generate_communicator_card(
         mission_anchor = 'middle'
 
     # ── Topics as typography (no badges) ─────────────────────────────
-    visible = list(normalize_topics(topics))[:8]
+    visible = list(normalize_topics(topics))
     chunks = chunk_topics(visible, max_lines=2)
 
     if is_wide:


### PR DESCRIPTION
Removes the eight-topic cap from verified communicator cards so every verified topic is rendered when space allows.