### PR TITLE
Exclude flaky citation hosts from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -93,6 +93,8 @@ jobs:
             --exclude "^https://profith\\.ugr\\.es"
             --exclude "^https://ouci\\.dntb\\.gov\\.ua"
             --exclude "^https://(?:www\\.)?jddonline\\.com"
+            --exclude "^https://www\\.ema\\.europa\\.eu/"
+            --exclude "^https://cdr\\.lib\\.unc\\.edu/"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
Excludes two citation hosts that fail under automated link checking: EMA pages returning 404 to the checker and UNC repository links timing out on GitHub Actions. No article content changes.