### PR TITLE
Exclude sweeteners.org from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -67,6 +67,7 @@ jobs:
             --exclude "^https://www\\.anid\\.cl/"
             --exclude "^https://www\\.nifa\\.usda\\.gov/"
             --exclude "^https://www\\.daytwo\\.com/"
+            --exclude "^https://www\\.sweeteners\\.org/"
             --exclude "^https://(?:www\\.)?nationalacademies\\.org/read/"
             --exclude "^https://nap\\.nationalacademies\\.org/read/"
             --exclude "^https://(?:www\\.)?link\\.springer\\.com"


### PR DESCRIPTION
The current `main` link-checker run now only fails on a timeout for `https://www.sweeteners.org/` in `nutrition/Fiber & Gut Health/do-artificial-sweeteners-wreck-your-gut.md`.

The site is reachable in a browser, so this treats it as a flaky host and excludes it from automated link checking rather than changing article content.