### PR TITLE
Exclude Samsung newsroom from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -94,6 +94,7 @@ jobs:
             --exclude "^https://profith\\.ugr\\.es"
             --exclude "^https://ouci\\.dntb\\.gov\\.ua"
             --exclude "^https://(?:www\\.)?jddonline\\.com"
+            --exclude "^https://news\\.samsung\\.com/"
             --exclude "^https://ods\\.od\\.nih\\.gov/"
             --exclude "^https://publications\\.rwth-aachen\\.de/"
             --exclude "^https://www\\.ema\\.europa\\.eu/"


### PR DESCRIPTION
## Summary
- Exclude `https://news.samsung.com/` from the link checker because Samsung returns `403 Forbidden` to automated CI requests.
- Keep the Samsung URL in article citations/product-claim documentation.

## Card status
- Current `main` already has Abhinav's updated card data: 2,392 citations, 286 commits, plus `musculoskeletal-health` and `dermatology` topics.
- The latest Pages deployment for commit `398b80c` was still in progress when checked, so the live contributor page may lag behind the updated tracked card assets.

## Checks
- Parsed `.github/workflows/link-checker.yml` with PyYAML.
- Ran `git diff --cached --check` before commit.
- Confirmed only `.github/workflows/link-checker.yml` is changed.