### PR TITLE
Improve contributor profiles and link checks

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -94,6 +94,7 @@ jobs:
             --exclude "^https://profith\\.ugr\\.es"
             --exclude "^https://ouci\\.dntb\\.gov\\.ua"
             --exclude "^https://(?:www\\.)?jddonline\\.com"
+            --exclude "^https://news\\.samsung\\.com/"
             --exclude "^https://ods\\.od\\.nih\\.gov/"
             --exclude "^https://publications\\.rwth-aachen\\.de/"
             --exclude "^https://www\\.ema\\.europa\\.eu/"

--- a/wearables/Wearable Fitness Trackers/body-composition-biological-age-healthspan-scores.md
+++ b/wearables/Wearable Fitness Trackers/body-composition-biological-age-healthspan-scores.md
@@ -142,7 +142,7 @@ The problem is not that all of these signals are meaningless. Some inputs are re
 
 The problem is label inflation. A signal that may support a narrow statement becomes a marketed age, healthspan, recovery, or metabolic-health score. Then the score is exported without the caveats, measurement conditions, algorithm details, validation cohort, or uncertainty interval.
 
-For human coaching, that may be tolerable. For AI-ingested health data, it is not.
+For human coaching, that may be tolerable. For context-stripped health-data systems, it is not.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Exclude `https://news.samsung.com/` from link checks because the host returns `403 Forbidden` in GitHub Actions.
- Keep the Samsung URL in article citations and product-claim documentation.
- Adjust one wearable article sentence to use neutral health-data wording.
- Replace the contributor profile contribution list with a cleaner table: Article, Area, Work, Citations, and PR.

## Checks
- Generated the contributor profile site locally.
- Rechecked the updated article content after the wording change.