### PR TITLE
Exclude blocked citation hosts from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -99,6 +99,9 @@ jobs:
             --exclude "^https://publications\\.rwth-aachen\\.de/"
             --exclude "^https://www\\.ema\\.europa\\.eu/"
             --exclude "^https://cdr\\.lib\\.unc\\.edu/"
+            --exclude "^https://actaorthop\\.org/"
+            --exclude "^https://apjcn\\.qdu\\.edu\\.cn/"
+            --exclude "^https://insight\\.jci\\.org/"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
Exclude citation hosts that fail automated GitHub Actions link-check requests while keeping the article citations unchanged. This covers actaorthop.org, apjcn.qdu.edu.cn, and insight.jci.org based on the latest main-branch link-checker failure.