### PR TITLE
Fix contributor table visibility

### DIFF
--- a/.github/scripts/generate_site.py
+++ b/.github/scripts/generate_site.py
@@ -534,7 +534,7 @@ def render_profile(profile):
       </div>
     </section>
 
-    <section class="section reveal">
+    <section class="section">
       <h2>Contributions</h2>
       <div class="contribution-list">
         {render_contributions(profile['contributions'])}


### PR DESCRIPTION
Summary:
- Remove the reveal animation gate from contributor profile contribution tables.
- Keeps large tables visible immediately, including Abhinav's 205-row contribution table.

Checks:
- python .github/scripts/generate_site.py
- python -m py_compile .github/scripts/generate_site.py
- git diff --check HEAD~1..HEAD