### PR TITLE
Exclude FITTR product link from checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -102,6 +102,7 @@ jobs:
             --exclude "^https://actaorthop\\.org/"
             --exclude "^https://apjcn\\.qdu\\.edu\\.cn/"
             --exclude "^https://insight\\.jci\\.org/"
+            --exclude "^https://shop\\.fittr\\.care/products/fittr-hart-ring$"
             --timeout 30
             '**/*.md'
           fail: true


### PR DESCRIPTION
Summary:
- Exclude the FITTR Hart Ring product URL that returns 503 to GitHub Actions.
- Keep the citation/product URL in the article unchanged.

Checks:
- YAML parse passed for link-checker.yml
- git diff --check