### PR TITLE
Set dark root background to prevent white overscroll flash

### DIFF
--- a/site-src/assets/styles.css
+++ b/site-src/assets/styles.css
@@ -20,6 +20,11 @@
   box-sizing: border-box;
 }
 
+html {
+  /* dark base so a fast/overscroll "rubber-band" reveals the theme, not white */
+  background-color: var(--bg-0);
+}
+
 body {
   margin: 0;
   font-family: 'DM Sans', sans-serif;


### PR DESCRIPTION
Fixes the white flash seen when scrolling fast / overscrolling on touchscreens and touchpads. The dark theme is painted on `body`, but the `html` root canvas behind it had no background and fell back to white, which showed in the rubber-band region at the top and bottom. Setting `html { background-color: var(--bg-0); }` makes the overscroll area dark instead of white. Single CSS rule; no other changes.