### PR TITLE
Keep post-merge updates writable

### DIFF
--- a/.github/workflows/contributor-tracker.yml
+++ b/.github/workflows/contributor-tracker.yml
@@ -18,7 +18,10 @@
 name: Track Contributors
 
 on:
-  pull_request:
+  # Fork PRs get a read-only token on pull_request, so the tracker
+  # cannot push the generated contributor-update PR after merge.
+  # pull_request_target runs trusted workflow code from main.
+  pull_request_target:
     types: [closed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Updates the closed-PR automation trigger so merged fork PRs can complete the generated update branch step. The job still runs from the base branch after merge, so it does not execute fork-side workflow code.\n\nValidation:\n- Recovered PR #271 stats through PR #272.\n- Link Checker and Deploy Profiles Site passed after PR #272 merged.