### PR TITLE
Exclude Cochrane site from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -58,6 +58,7 @@ jobs:
             --exclude "^https://www\\.nejm\\.org"
             --exclude "^https://www\\.ahajournals\\.org"
             --exclude "^https://www\\.cochranelibrary\\.com"
+            --exclude "^https://www\\.cochrane\\.org/"
             --exclude "^https://www\\.researchgate\\.net"
             --exclude "^https://fdc\\.nal\\.usda\\.gov/fdc-app\\.html"
             --exclude "^https://www\\.foodsafety\\.gov/"


### PR DESCRIPTION
Summary:
- Add a narrow Lychee exclude for www.cochrane.org after the main-branch Link Checker failed on valid Cochrane pages returning 403.

Checks:
- git diff --check