### PR TITLE
Exclude two CDC pages from link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -67,6 +67,8 @@ jobs:
             --exclude "^https://www\\.fda\\.gov/food/food-allergies/faster-act-sesame-ninth-major-food-allergen"
             --exclude "^https://www\\.anid\\.cl/"
             --exclude "^https://www\\.nifa\\.usda\\.gov/"
+            --exclude "^https://www\.cdc\.gov/contraception/hcp/usmec/combined-hormonal-contraceptives\.html$"
+            --exclude "^https://www\.cdc\.gov/diabetes/risk-factors/index\.html$"
             --exclude "^https://www\\.daytwo\\.com/"
             --exclude "^https://www\\.sweeteners\\.org/"
             --exclude "^https://(?:www\\.)?nationalacademies\\.org/read/"


### PR DESCRIPTION
## Summary

- Exclude the two confirmed live CDC pages that return HTTP 403 to the automated link checker.
- Keep every other CDC URL covered by link checking.

## Checks

- Workflow YAML parsing
- Exact-match and non-match regex checks