### PR TITLE
Add chrononutrition and GLP-1 treatment articles

### DIFF
--- a/nutrition/Meal Frequency & Intermittent Fasting/Dinner Timing & Chrononutrition/dinner-timing-and-chrononutrition.md
+++ b/nutrition/Meal Frequency & Intermittent Fasting/Dinner Timing & Chrononutrition/dinner-timing-and-chrononutrition.md
@@ -1,0 +1,119 @@
+# Dinner Timing & Chrononutrition
+
+The most debated questions about dinner timing, daily eating windows, calorie distribution, meal regularity, long-term health, and population-specific meal patterns.
+
+**Status:** Articles are available for dinner timing and daily eating windows. The remaining sections are seeking contributors.
+
+---
+
+## [Does Dinner Timing Matter?](does-dinner-timing-matter.md)
+
+This article examines the timing of the final main meal while distinguishing clock time, time before sleep, and biological time. It does not cover shortening the entire eating window or changing how daily calories are distributed across meals.
+
+**Competing claims:**
+
+1. Eating dinner earlier changes glucose regulation, insulin response, appetite, energy expenditure, body weight, sleep, and overnight metabolism
+2. Dinner timing has no independent effect when food, calories, sleep, and physical activity are matched
+3. The interval between dinner and sleep matters more than dinner clock time
+4. Timing relative to biological night or melatonin onset matters more than clock time or bedtime
+5. Chronotype changes how people respond to the same dinner time
+6. Meal size and composition determine the effects attributed to early or late dinner
+
+**Evidence needed:** Randomized early-vs-late dinner trials using the same meals and calories, dinner-to-sleep interval studies, circadian-phase measurements, chronotype-stratified analyses, sleep outcomes, postprandial metabolic measurements, and body-weight outcomes.
+
+---
+
+## [Is There an Optimal Daily Eating Window?](is-there-an-optimal-daily-eating-window.md)
+
+This article examines the period between the first and final caloric intake of the day. It covers both eating-window duration and placement but does not treat moving dinner alone as time-restricted eating.
+
+**Competing claims:**
+
+1. Shorter daily eating windows produce different outcomes from longer eating windows
+2. Early eating windows produce different outcomes from late eating windows of the same duration
+3. Eating-window duration matters more than whether the window occurs early or late
+4. Eating-window placement matters more than its duration
+5. Self-selected eating windows produce different adherence and outcomes from prescribed windows
+6. Time-restricted eating affects outcomes only when it changes calorie intake
+7. Time-restricted eating affects outcomes independently of calorie intake
+
+**Evidence needed:** Early-vs-late eating-window trials, short-vs-long window trials, factorial studies separating duration from placement, matched-calorie interventions, self-selected-vs-prescribed window comparisons, and adherence data.
+
+---
+
+## Does Calorie Distribution Across the Day Matter?
+
+This article examines how daily calories are divided across breakfast, lunch, dinner, and snacks. It does not treat calorie distribution as equivalent to dinner timing or eating-window restriction.
+
+**Competing claims:**
+
+1. Consuming more daily calories at breakfast and lunch produces different outcomes from consuming more at dinner
+2. The percentage of daily calories consumed at dinner matters more than dinner clock time
+3. Calorie distribution affects appetite and subsequent food intake
+4. Calorie distribution affects metabolism independently of total calorie intake
+5. Total daily calorie intake determines outcomes regardless of how calories are distributed
+6. Calorie distribution interacts with sleep timing, chronotype, and physical activity
+
+**Evidence needed:** Front-loaded-vs-back-loaded feeding trials, matched-calorie interventions, meal-size comparisons, appetite measurements, subsequent-intake studies, and chronotype- or activity-stratified analyses.
+
+---
+
+## Does Meal Regularity Matter?
+
+This article examines day-to-day variation in meal times and eating windows. It does not evaluate whether the average meal time should be early or late.
+
+**Competing claims:**
+
+1. Consistent meal timing produces different outcomes from irregular meal timing
+2. Regularity matters regardless of whether meals occur early or late
+3. Average meal timing matters more than day-to-day regularity
+4. Regularity of the entire eating window matters more than regularity of dinner alone
+5. Weekday-weekend changes in meal timing affect circadian alignment
+6. Associations involving irregular meals are explained by work schedules, sleep disruption, health status, or socioeconomic conditions
+
+**Evidence needed:** Regular-vs-irregular meal-timing trials, repeated meal-timing measurements, weekday-weekend comparisons, eating-window variability studies, shift-work analyses, and studies separating average timing from timing variability.
+
+---
+
+## Does Meal Timing Affect Long-Term Disease and Longevity?
+
+This article examines diabetes, cardiovascular disease, cancer, ageing, and mortality. Short-term biomarkers, appetite changes, and weight loss belong in the earlier articles unless a study directly connects them to long-term clinical outcomes.
+
+**Competing claims:**
+
+1. Habitual late eating contributes to long-term disease and mortality
+2. Dinner timing is not independently associated with disease after accounting for diet, sleep, activity, and socioeconomic factors
+3. Eating-window duration is associated with long-term outcomes independently of dinner timing
+4. Meal regularity is associated with long-term outcomes independently of average meal timing
+5. Short-term metabolic responses can be used to predict long-term health effects
+6. Long-term effects cannot be determined from short-duration feeding studies
+7. Associations between meal timing and mortality reflect illness, frailty, appetite changes, or reverse causation
+
+**Evidence needed:** Prospective cohorts with repeated timing measurements, clinical-event data, mortality analyses, ageing outcomes, long-duration randomized trials, mediation analyses, and studies addressing residual confounding and reverse causation.
+
+---
+
+## Who May Need a Different Meal-Timing Pattern?
+
+This article examines clinical, nutritional, occupational, and performance-related populations. It includes the late-snack debate and does not determine the general-population effects of early or late dinner.
+
+**Competing claims:**
+
+1. Long overnight fasting produces different effects in people with cirrhosis, frailty, sarcopenia, pregnancy, diabetes, or undernutrition
+2. Late snacks help some populations meet energy, protein, recovery, or medication-related requirements
+3. A small late snack produces different effects from a full late dinner
+4. Athletes who train in the evening require different meal timing from sedentary populations
+5. Shift workers require meal-timing strategies based on their sleep and work cycles
+6. People using glucose-lowering medication require different fasting and meal-timing considerations
+7. The same meal-timing recommendations can be applied across populations unless a contraindication exists
+8. Meal timing should be individualized according to health status, nutritional requirements, medication use, and training schedule
+
+**Evidence needed:** Population-specific meal-timing trials, late-snack studies, overnight fasting research, muscle and nutritional-status outcomes, pregnancy data, medication-related hypoglycemia studies, athlete recovery studies, and shift-worker interventions.
+
+---
+
+## How to Contribute
+
+Pick a section. Find the relevant meta-analyses, systematic reviews, or high-quality RCTs. Summarize what the evidence shows, including limitations.
+
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for citation standards.

--- a/nutrition/Meal Frequency & Intermittent Fasting/Dinner Timing & Chrononutrition/does-dinner-timing-matter.md
+++ b/nutrition/Meal Frequency & Intermittent Fasting/Dinner Timing & Chrononutrition/does-dinner-timing-matter.md
@@ -1,0 +1,170 @@
+# Does Dinner Timing Matter?
+
+Dinner timing can affect acute glucose handling and overnight fuel use, even when prescribed food and calories are matched. Evidence that dinner timing independently changes total daily energy expenditure, produces sustained weight loss, or improves sleep is much weaker. For generally healthy adults, there is no evidence-based universal rule to finish dinner by a particular clock time or leave exactly two or three hours before bed. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Vujović et al., 2022](https://doi.org/10.1016/j.cmet.2022.09.007); [Saidi et al., 2024](https://doi.org/10.1016/j.smrv.2024.101953); [Madjd et al., 2021](https://doi.org/10.1017/S0007114520004456); [Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163); [Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+## Three meanings of “late dinner”
+
+Dinner timing can be expressed in three different ways:
+
+- **Clock time:** for example, 18:00 versus 22:00. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354))
+
+- **Time before sleep:** for example, five hours versus one hour before habitual bedtime. ([Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+- **Biological time:** whether dinner overlaps the biological evening, rising endogenous melatonin, or dim-light melatonin onset (DLMO). ([Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314); [Culnan et al., 2021](https://doi.org/10.1016/j.sleh.2021.01.001); [Huang et al., 2024](https://doi.org/10.1017/S0007114524001636))
+
+
+Several dinner trials change more than one of these at once. In the Gu trial, moving dinner from 18:00 to 22:00 while keeping bedtime at 23:00 changed clock time and the dinner-to-bed interval from five hours to one hour. Circadian phase was not measured. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354))
+
+Similarly, a trial comparing a glucose challenge four hours versus one hour before habitual bedtime also changed clock time and melatonin exposure. In the subset with melatonin measurements, melatonin was 3.5 times higher in the late condition. ([Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314))
+
+Therefore, the current dinner-specific trials do not establish whether clock time, proximity to sleep, or biological phase is the most important variable. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314); [Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+## Acute glucose regulation
+
+In a randomized crossover trial of 20 healthy adults, participants ate dinner at 18:00 or 22:00 with sleep fixed from 23:00 to 07:00. The late condition increased peak glucose by 18 percent and four-hour glucose area under the curve from 443.3 to 522.3 mg/dL·h. In the 17 participants with usable tracer data, it also reduced 14-hour cumulative oxidation of labeled dietary palmitate from 84.5 to 74.5 percent. Four-hour post-dinner insulin area under the curve and peak insulin did not differ significantly. The protocol prescribed the same total daily food and calories, although the positions of a 35-percent-energy dinner and a 10-percent-energy evening snack were swapped rather than simply moving an unchanged dinner. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354))
+
+A crossover trial in 12 healthy adults compared identical dinners at 18:00 and 21:00. Breakfast, lunch, and dinner were supplied, while recorded step counts and self-reported sleep timing did not differ significantly between conditions. The later dinner produced higher post-dinner and overnight glucose. Early dinner was followed by a lower respiratory quotient 30 and 60 minutes after breakfast, indicating greater relative fat use at those times, but there was no between-condition difference in post-breakfast energy expenditure. ([Nakamura et al., 2021](https://doi.org/10.3390/nu13072424))
+
+Another crossover experiment in 12 young adults compared dinner at 19:00, 20:00, 21:00, and 22:00. Compared with the fixed 19:00 condition, dinner at 20:00, 21:00, or 22:00 increased the post-dinner glucose rise and three-hour incremental area under the curve. Peak glucose was significantly higher only at 21:00, and there were no clear differences among the 20:00, 21:00, and 22:00 conditions. Only the three delayed conditions were randomized, and the longer interval from lunch to the later dinners may have contributed. ([Nakamura et al., 2024](https://doi.org/10.1111/jdi.14104))
+
+A recent partial null result comes from 13 healthy young women who ate a standardized dinner five hours or one hour before habitual bedtime for four days. Post-dinner glucose area under the curve showed a condition-by-day interaction, but follow-up comparisons did not reach statistical significance, and the following oral glucose tolerance test did not differ significantly between conditions. ([Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+Taken together, these trials make the strict claim that dinner timing has no independent acute effect difficult to defend. However, the trials are small, short, and dominated by healthy young adults, so they do not show that occasional late dinners cause diabetes or other clinical disease. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Nakamura et al., 2021](https://doi.org/10.3390/nu13072424); [Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+A systematic review published in July 2026 included 44 human meal-timing intervention studies, but 37 lasted no more than one week and the remaining seven lasted two to 12 weeks. It also evaluated meal timing across the day rather than isolating the final main meal. ([Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+## Insulin, appetite, energy expenditure, and lipids
+
+Insulin responses are not consistent across trials. Gu and colleagues found no significant difference in four-hour post-dinner insulin area under the curve or peak insulin despite higher glucose, whereas a large glucose-challenge trial found 6.7 percent lower insulin exposure in the late condition. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314))
+
+Late dinner altered triglyceride timing in the Gu trial, but mean triglyceride concentration across 20 hours was virtually identical between conditions. This supports altered overnight lipid handling, not a reliable increase in total triglyceride exposure. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354))
+
+Early dinner did not consistently improve appetite. In the Nakamura trial, eating at 18:00 produced greater hunger, desire to eat, and perceived capacity to eat around 23:00 than eating at 21:00. ([Nakamura et al., 2021](https://doi.org/10.3390/nu13072424))
+
+A crossover trial in 16 adults with overweight or obesity found that later eating increased hunger and reduced waking energy expenditure. However, it shifted the entire three-meal schedule by 250 minutes rather than manipulating dinner alone, so it cannot establish a dinner-specific appetite or energy-expenditure effect. ([Vujović et al., 2022](https://doi.org/10.1016/j.cmet.2022.09.007))
+
+## Biological time and melatonin
+
+Melatonin-related evidence comes from 845 adults who completed 75-g glucose challenges four hours and one hour before habitual bedtime. The late condition produced 8.3 percent higher glucose exposure and 6.7 percent lower insulin exposure. In the 588 participants with melatonin measurements, melatonin was 3.5-fold higher in the late condition. Effects were stronger in carriers of the glucose-raising MTNR1B risk allele. This was a glucose challenge rather than a mixed dinner, and lighting also differed between conditions. DLMO was not reported or used to align the challenges in the publication, although the trial registry lists DLMO measurement in the early condition. ([Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314); [ClinicalTrials.gov, NCT03036592](https://clinicaltrials.gov/study/NCT03036592))
+
+A tightly controlled circadian-misalignment experiment provides cleaner mechanistic evidence that biological phase itself matters. With identical meals, postprandial glucose was 17 percent higher in the biological evening than in the biological morning, independently of the scheduled behavioral cycle. A 12-hour inversion of the behavioral cycle produced an additional independent increase of approximately 6 percent. This experiment was not a dinner-timing intervention. ([Morris et al., 2015](https://doi.org/10.1073/pnas.1418955112))
+
+Studies that measured DLMO in ordinary living conditions are observational and inconsistent. In 97 adults, timing of the last meal relative to DLMO was not associated with BMI or body fat in the full sample. An association with BMI appeared only in an exploratory post hoc later-DLMO subgroup, without a formal subgroup interaction. ([Culnan et al., 2021](https://doi.org/10.1016/j.sleh.2021.01.001)) In 133 Chinese young adults, later final eating relative to DLMO was associated with several adiposity measures in women but not men. However, the study did not report a formal sex-by-timing interaction, so the difference between women and men is not established. ([Huang et al., 2024](https://doi.org/10.1017/S0007114524001636))
+
+Biological timing is therefore a credible mechanism, but current evidence does not prove that it matters more than dinner-to-sleep interval or clock time. ([Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314); [Morris et al., 2015](https://doi.org/10.1073/pnas.1418955112); [Culnan et al., 2021](https://doi.org/10.1016/j.sleh.2021.01.001); [Huang et al., 2024](https://doi.org/10.1017/S0007114524001636))
+
+## Does chronotype change the response?
+
+In the Gu trial, habitually earlier sleepers showed larger glucose responses to late dinner. Each hour-earlier habitual sleep onset predicted a 6.84 percent larger late-dinner effect on glucose area under the curve. This was an exploratory analysis in only 20 participants, and circadian phase was not measured. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354))
+
+A separate crossover trial found that early chronotypes had worse glucose responses to a high-glycemic meal at 20:00 than at 07:00, while late chronotypes had similar incremental glucose responses at both times. Because it compared morning with evening meals rather than early with late dinners and used questionnaire-based chronotype rather than DLMO, it provides supportive but indirect evidence. ([Stutz et al., 2024](https://doi.org/10.1007/s00394-024-03372-4))
+
+Chronotype may modify dinner responses, but the evidence is not strong enough to assign different clinical dinner cutoffs to morning and evening types. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Stutz et al., 2024](https://doi.org/10.1007/s00394-024-03372-4))
+
+## Sleep
+
+Controlled sleep findings point in contradictory directions. ([Duan et al., 2021](https://doi.org/10.2147/NSS.S301113); [Lehmann et al., 2023](https://doi.org/10.1123/ijsnem.2022-0014); [Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+A single-night-per-condition analysis of the Gu crossover trial found no adverse whole-night difference in conventional sleep-stage distribution or arousal frequency between dinner five hours and one hour before bed. However, late dinner altered EEG spectral power, with more delta power and less alpha and beta power early in the night. The delta and alpha differences later reversed, while the beta difference attenuated. ([Duan et al., 2021](https://doi.org/10.2147/NSS.S301113))
+
+In 12 male adolescent rugby players, moving dinner from 3.5 hours to 1.5 hours before bed for five days increased total sleep by 24 minutes, improved sleep efficiency, and reduced wake after sleep onset. This highly specialized population limits generalization. ([Lehmann et al., 2023](https://doi.org/10.1123/ijsnem.2022-0014))
+
+In contrast, the 2026 crossover trial in 13 young women found that dinner one hour before bed shortened sleep by approximately 33 minutes after four days and worsened sleep efficiency and fragmentation. This trial was funded by the Institute for Food and Health Science at Yazuya Co., Ltd., a health-food company. The authors declared no competing interests, but the tiny result should be interpreted with the funding and design limitations in mind, including the absence of menstrual-cycle control and the assessment of numerous sleep outcomes. ([Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+A systematic scoping review characterized the chrono-nutrition and sleep literature as heterogeneous and preliminary. It did not establish an optimal dinner-to-bed interval or validate a universal clinical two-hour or three-hour rule. ([Saidi et al., 2024](https://doi.org/10.1016/j.smrv.2024.101953))
+
+## Body weight
+
+A dinner-specific weight-loss trial randomized 82 premenopausal Iranian women with overweight or obesity, all of whom habitually ate dinner at or after 22:30, to a hypocaloric diet with dinner at 19:00 to 19:30 or 22:30 to 23:00 for 12 weeks. Weight loss was 6.74 kg with early dinner and 4.81 kg with late dinner, a difference of 1.93 kg. The prescribed calorie deficit, meal distribution, and macronutrients were similar. However, food was not provided, food intake and timing were self-reported, and physical activity was assessed with pedometers and logs rather than controlled. Seventy-five participants completed the trial, although the primary analysis included all 82 using multiple imputation. The trial was conducted through the private NovinDiet clinic; the authors declared no conflict of interest and reported institutional research funding. ([Madjd et al., 2021](https://doi.org/10.1017/S0007114520004456))
+
+The cited reviews did not identify an independent replication in another comparably long dinner-only randomized trial. ([Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878); [Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163))
+
+A 2024 meta-analysis of 29 meal-timing RCTs found modest weight advantages for earlier calorie distribution, time-restricted eating, and lower meal frequency. However, 22 trials had high risk of bias and none had low overall risk. For weight outcomes, the certainty of evidence was low for time-restricted eating and earlier calorie distribution and very low for lower meal frequency. Three of the four trials in the review's calorie-distribution category changed calorie distribution across the day; the fourth was the Madjd dinner-timing trial, which kept the prescribed calorie distribution unchanged. ([Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163))
+
+A 2026 meta-analysis of eight observational studies found a modest association between broadly defined late eating and obesity, with a combined odds ratio or hazard ratio of 1.17. Definitions included dinner near bed, night snacks, waking to eat, and eating after 21:00. In the subgroup specifically defined as dinner within two hours of bedtime, the estimate was 1.07 with a 95 percent confidence interval from 0.83 to 1.39, which was not statistically significant. The overall evidence was heterogeneous and cannot establish that late eating caused obesity. ([Park et al., 2026](https://doi.org/10.1093/nutrit/nuag087))
+
+The cited systematic reviews identified no dinner-timing RCT that tested whether moving dinner earlier prevents incident obesity, type 2 diabetes, cardiovascular disease, or other long-term clinical outcomes. ([Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878); [Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163))
+
+## Does meal size or composition explain the effects?
+
+Meal composition cannot explain every result because several crossover trials kept dinner energy and macronutrients the same while observing timing-related glucose or sleep differences. ([Nakamura et al., 2021](https://doi.org/10.3390/nu13072424); [Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+However, much of the mechanistic evidence comes from substantial carbohydrate loads. The Gu dinner provided 50 percent of energy from carbohydrate, while the large melatonin trial used 75 g of pure glucose rather than a mixed meal. The size of any timing effect for a small or lower-carbohydrate dinner is therefore uncertain. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314))
+
+The cited reviews identified no dinner-specific factorial trial that adequately varied both timing and meal composition while holding calories, sleep, activity, and circadian phase constant. ([Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878); [Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163))
+
+## Quick reference
+
+- **Post-dinner and overnight glucose:** later dinner can worsen it acutely, but trials are small and short. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Nakamura et al., 2021](https://doi.org/10.3390/nu13072424))
+
+- **Insulin:** direction varies by population and protocol. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314))
+
+- **Fat metabolism:** timing and tracer-measured oxidation may change, but higher total triglyceride exposure is not established. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354))
+
+- **Appetite and energy expenditure:** insufficient dinner-only evidence. ([Nakamura et al., 2021](https://doi.org/10.3390/nu13072424); [Vujović et al., 2022](https://doi.org/10.1016/j.cmet.2022.09.007))
+
+- **Sleep:** controlled results are inconsistent. ([Duan et al., 2021](https://doi.org/10.2147/NSS.S301113); [Lehmann et al., 2023](https://doi.org/10.1123/ijsnem.2022-0014); [Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+- **Weight loss:** one positive 12-week dinner trial, without an independent replication identified by the cited reviews. ([Madjd et al., 2021](https://doi.org/10.1017/S0007114520004456); [Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163); [Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+- **Long-term disease prevention:** not tested in dinner-timing RCTs identified by the cited reviews. ([Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+
+## Practical interpretation
+
+- For generally healthy adults, a universal instruction such as “finish dinner before 7 p.m.” is not supported because the same clock time can represent different biological and sleep-relative times for different people. ([Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314); [Stutz et al., 2024](https://doi.org/10.1007/s00394-024-03372-4))
+
+- Condition-specific advice can differ. For people with gastroesophageal reflux disease symptoms, the American College of Gastroenterology conditionally suggests avoiding meals within two to three hours of bedtime, although the supporting evidence is low quality. ([Katz et al., 2022](https://pmc.ncbi.nlm.nih.gov/articles/PMC8754510/))
+
+- A reasonable conservative interpretation is to avoid making a substantial carbohydrate-rich dinner within the final hour before sleep a routine when an earlier meal is practical. This matches the exposure most consistently associated with worse acute glucose handling, but it is not proof of a required one-, two-, or three-hour cutoff. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314))
+
+- If sleep is the main concern, individual response is more informative than a universal gap because controlled studies report null, beneficial, and adverse sleep effects. ([Duan et al., 2021](https://doi.org/10.2147/NSS.S301113); [Lehmann et al., 2023](https://doi.org/10.1123/ijsnem.2022-0014); [Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0))
+
+- Earlier dinner cannot yet be relied upon as a weight-loss intervention when food intake is otherwise unchanged. The evidence is limited to one positive dinner-specific trial without an independent replication identified by the cited reviews. ([Madjd et al., 2021](https://doi.org/10.1017/S0007114520004456); [Liu et al., 2024](https://doi.org/10.1001/jamanetworkopen.2024.42163); [Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+
+## Funding and conflicts
+
+Several key experiments and reviews summarized here were supported principally by public, nonprofit, or institutional funding rather than direct commercial study funding. This includes the Gu, Nakamura (2021), Garaulet, and Slebe studies. The Duan sleep study was a secondary analysis of the publicly funded Gu trial. ([Gu et al., 2020](https://doi.org/10.1210/clinem/dgaa354); [Nakamura et al., 2021](https://doi.org/10.3390/nu13072424); [Garaulet et al., 2022](https://doi.org/10.2337/dc21-1314); [Duan et al., 2021](https://doi.org/10.2147/NSS.S301113); [Slebe et al., 2026](https://doi.org/10.1016/j.numecd.2026.104878))
+
+The Vujović experiment was principally publicly funded, although Vujović and Scheer disclosed commercial relationships that were described as unrelated to the study. The small 2026 Enomoto trial funded by Yazuya Co., Ltd. is a direct commercial-funding example among the dinner-timing experiments summarized here. The Morris circadian experiment was principally publicly and institutionally funded. One coauthor disclosed multiple external financial relationships, including investigator-initiated grants from Sepracor/Sunovion and Cephalon/Teva, Takeda honoraria and educational support, and consulting or advisory roles involving Dinsmore, Matsutani America, and Wake Forest University Medical Center. ([Vujović et al., 2022](https://doi.org/10.1016/j.cmet.2022.09.007); [Enomoto et al., 2026](https://doi.org/10.1186/s40101-026-00430-0); [Morris et al., 2015](https://doi.org/10.1073/pnas.1418955112))
+
+## References
+
+- [Slebe R, Wenker E, Schoonmade LJ, et al. Effects of timing of meal intake on glucose metabolism: a systematic review and meta-analysis of human intervention studies. Nutrition, Metabolism and Cardiovascular Diseases. 2026.](https://doi.org/10.1016/j.numecd.2026.104878)
+
+- [Gu C, Brereton N, Schweitzer A, et al. Metabolic Effects of Late Dinner in Healthy Volunteers: A Randomized Crossover Clinical Trial. J Clin Endocrinol Metab. 2020;105(8):2789-2802.](https://doi.org/10.1210/clinem/dgaa354)
+
+- [Nakamura K, Tajiri E, Hatamoto Y, et al. Eating Dinner Early Improves 24-h Blood Glucose Levels and Boosts Lipid Metabolism after Breakfast the Next Day: A Randomized Cross-Over Trial. Nutrients. 2021;13(7):2424.](https://doi.org/10.3390/nu13072424)
+
+- [Nakamura F, Shimba Y, Toyonaga S, et al. Delayed dinnertime impairs glucose tolerance in healthy young adults. J Diabetes Investig. 2024;15(2):172-176.](https://doi.org/10.1111/jdi.14104)
+
+- [Garaulet M, Qian J, Florez JC, et al. Interplay of Dinner Timing and MTNR1B Type 2 Diabetes Risk Variant on Glucose Tolerance and Insulin Secretion: A Randomized Crossover Trial. Diabetes Care. 2022;45(3):512-519.](https://doi.org/10.2337/dc21-1314)
+
+- [ClinicalTrials.gov. MTNR1B SNP*Food Timing Interaction on Glucose Control in a Late Eater Mediterranean Population. NCT03036592.](https://clinicaltrials.gov/study/NCT03036592)
+
+- [Morris CJ, Yang JN, Garcia JI, et al. Endogenous circadian system and circadian misalignment impact glucose tolerance via separate mechanisms in humans. Proc Natl Acad Sci USA. 2015;112(17):E2225-E2234.](https://doi.org/10.1073/pnas.1418955112)
+
+- [Culnan E, Reid KJ, Zee PC, Crowley SJ, Baron KG. Meal timing relative to DLMO: Associations with BMI and body fat. Sleep Health. 2021;7(3):339-344.](https://doi.org/10.1016/j.sleh.2021.01.001)
+
+- [Huang Y, Xu YX, Shen YT, et al. Sex-specific association between later circadian timing of food intake and adiposity among Chinese young adults living in real-world settings. Br J Nutr. 2024;132:1629-1636.](https://doi.org/10.1017/S0007114524001636)
+
+- [Stutz B, Krueger B, Goletzke J, et al. Glycemic response to meals with a high glycemic index differs between morning and evening: a randomized cross-over controlled trial among students with early or late chronotype. Eur J Nutr. 2024;63:1593-1604.](https://doi.org/10.1007/s00394-024-03372-4)
+
+- [Vujović N, Piron MJ, Qian J, et al. Late isocaloric eating increases hunger, decreases energy expenditure, and modifies metabolic pathways in adults with overweight and obesity. Cell Metab. 2022;34(10):1486-1498.e7.](https://doi.org/10.1016/j.cmet.2022.09.007)
+
+- [Duan D, Gu C, Polotsky VY, Jun JC, Pham LV. Effects of dinner timing on sleep stage distribution and EEG power spectrum in healthy volunteers. Nat Sci Sleep. 2021;13:601-612.](https://doi.org/10.2147/NSS.S301113)
+
+- [Lehmann L, Saidi O, Giacomoni M, et al. A Delayed Evening Meal Enhances Sleep Quality in Young Rugby Players. Int J Sport Nutr Exerc Metab. 2023;33(1):39-46.](https://doi.org/10.1123/ijsnem.2022-0014)
+
+- [Enomoto M, Kitamura S, Kunieda T, Eto T. Effects of later dinner timing on subsequent metabolic function and nocturnal sleep in healthy young women. J Physiol Anthropol. 2026;45:12.](https://doi.org/10.1186/s40101-026-00430-0)
+
+- [Saidi O, Rochette E, Dambel L, St-Onge MP, Duché P. Chrono-nutrition and sleep: lessons from the temporal feature of eating patterns in human studies - A systematic scoping review. Sleep Med Rev. 2024;76:101953.](https://doi.org/10.1016/j.smrv.2024.101953)
+
+- [Madjd A, Taylor MA, Delavari A, Malekzadeh R, Macdonald IA, Farshchi HR. Effects of consuming later evening meal versus earlier evening meal on weight loss during a weight loss diet: a randomised clinical trial. Br J Nutr. 2021;126(4):632-640.](https://doi.org/10.1017/S0007114520004456)
+
+- [Liu HY, Eso AA, Cook N, O’Neill HM, Albarqouni L. Meal Timing and Anthropometric and Metabolic Outcomes: A Systematic Review and Meta-Analysis. JAMA Netw Open. 2024;7(11):e2442163.](https://doi.org/10.1001/jamanetworkopen.2024.42163)
+
+- [Park Y, Cho H, Myung SK. Late Eating and Obesity: A Meta-Analysis of Observational Studies. Nutr Rev. 2026.](https://doi.org/10.1093/nutrit/nuag087)
+
+- [Katz PO, Dunbar KB, Schnoll-Sussman FH, Greer KB, Yadlapati R, Spechler SJ. ACG Clinical Guideline for the Diagnosis and Management of Gastroesophageal Reflux Disease. Am J Gastroenterol. 2022;117(1):27-56.](https://pmc.ncbi.nlm.nih.gov/articles/PMC8754510/)

--- a/nutrition/Meal Frequency & Intermittent Fasting/Dinner Timing & Chrononutrition/is-there-an-optimal-daily-eating-window.md
+++ b/nutrition/Meal Frequency & Intermittent Fasting/Dinner Timing & Chrononutrition/is-there-an-optimal-daily-eating-window.md
@@ -1,0 +1,117 @@
+# Is There an Optimal Daily Eating Window?
+
+No single daily eating window has been shown to be optimal for everyone. Earlier windows may modestly outperform later windows for some metabolic markers, but recent direct comparisons are mixed. Comparisons across broad window-duration categories show no consistent ordering of benefits, and reduced calorie intake appears to be a major contributor to free-living weight loss. Small controlled studies leave open the possibility of calorie-independent effects on selected short-term markers. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071); [Chang et al., 2024](https://doi.org/10.1016/j.isci.2024.109000); [Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y); [Peters et al., 2025](https://doi.org/10.1126/scitranslmed.adv6787))
+
+## What the eating window measures
+
+Here, the daily eating window is the interval between the first and final caloric intake of the day. Time-restricted eating (TRE) shortens that entire interval. Moving dinner earlier or later without changing the span from the first calorie to the last is a meal-timing change, not necessarily TRE. ([Koppold et al., 2024](https://doi.org/10.1016/j.cmet.2024.06.013))
+
+Duration and placement are separate variables. A six-hour window from 08:00 to 14:00 and one from 14:00 to 20:00 have the same duration but different placement. An early six-hour window and an early ten-hour window have similar placement but different duration.
+
+## What the overall evidence shows
+
+A 2026 systematic review and network meta-analysis included 41 randomized trials and 2,287 participants. Compared with usual eating patterns, TRE produced modest average reductions in body weight, body mass index, fat mass, waist circumference, systolic blood pressure, fasting glucose, fasting insulin, and triglycerides. It did not significantly improve HbA1c or HOMA-IR. TRE also produced a modest average reduction of 0.84 kg in the combined fat-free mass/lean mass outcome, although these measures are not synonymous with skeletal muscle mass. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071); [Tinsley and Heymsfield, 2024](https://doi.org/10.1210/jendso/bvae164))
+
+These findings do not show that TRE prevents diabetes, cardiovascular events, or premature death. The trials mainly measured short-term risk markers, and the review found no trials assessing incident metabolic syndrome or type 2 diabetes. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+## Early versus late windows
+
+The 2026 network meta-analysis favored early over late TRE for body weight by 1.15 kg, waist circumference by 3.19 cm, and fasting insulin by 3.32 µIU/mL. The weight and fasting-insulin estimates were rated high-certainty, while the waist estimate was rated low-certainty. Timing results were more consistent than duration results. However, direct head-to-head evidence was sparse, and the significant network estimates for body weight and fasting insulin were materially supported by indirect comparisons across trials with different participants, window lengths, calorie changes, and co-interventions. The literature search also ended on 3 January 2023, so the review did not include important 2024 and 2025 trials. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+In a more recent 12-week RCT of 197 adults with overweight or obesity, all groups received Mediterranean-diet and lifestyle education. Participants assigned to TRE followed an early, late, or self-selected eight-hour window, while usual-care participants maintained an eating window of at least 12 hours. None of the TRE schedules produced an additional reduction in the primary visceral-fat outcome relative to usual care, and the TRE schedules did not differ from one another. All three TRE groups lost significantly more weight than usual care, with similar losses across the TRE schedules. Early TRE improved fasting and overnight glucose in secondary analyses, but it was not broadly superior to late TRE. ([Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y))
+
+An intended-isocaloric crossover trial compared 08:00 to 16:00 with 13:00 to 21:00 for two weeks each in 31 women with overweight or obesity. The windows did not differ for insulin sensitivity, 24-hour glucose, blood lipids, inflammation, or oxidative stress. Late eating was associated with slightly later self-reported sleep timing and a non-significant 24-minute trend toward a later estimated peripheral circadian phase derived from monocytes in the change analysis, although the end-of-phase estimate was 40 minutes later after late TRE than after early TRE. The early phase unexpectedly reduced intake by about 167 kcal/day and produced somewhat greater weight loss, so even this tightly monitored trial did not perfectly isolate clock time from energy intake. ([Peters et al., 2025](https://doi.org/10.1126/scitranslmed.adv6787))
+
+In another eight-week trial, early 08:00 to 16:00 TRE, late 12:00 to 20:00 TRE, and a 12-hour control schedule were all paired with the same prescribed 25 percent calorie deficit. Among 37 completers in this exploratory, underpowered trial, no statistically significant between-group differences were detected in the measured cardiometabolic outcomes. ([Queiroz et al., 2023](https://doi.org/10.1017/S0007114522001581))
+
+The best synthesis is therefore that earlier eating may have a small metabolic advantage on average, especially for some glucose and insulin markers, but same-duration direct trials do not show a large or universal advantage. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071); [Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y); [Peters et al., 2025](https://doi.org/10.1126/scitranslmed.adv6787))
+
+## Shorter versus longer windows
+
+Shorter is not consistently better. In the 2026 network meta-analysis, windows under eight hours ranked well for some measures of weight and waist circumference, but they also reduced the combined fat-free mass/lean mass outcome and increased total and LDL cholesterol relative to usual diets in network estimates. Eight-hour and longer windows each had scattered benefits, leaving no consistently superior duration. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+The clearest direct duration trial randomized adults with obesity to a four-hour window from 15:00 to 19:00, a six-hour window from 13:00 to 19:00, or no timing restriction for eight weeks. Both TRE groups reduced reported energy intake by about 550 kcal/day and lost about 3.2 percent of body weight; four hours did not outperform six hours. ([Cienfuegos et al., 2020](https://doi.org/10.1016/j.cmet.2020.06.018))
+
+Among trials covered by the 2026 review, no factorial RCT independently randomized both window duration and placement, such as six versus ten hours crossed with early versus late timing. Network rankings that combine direct and indirect evidence cannot determine whether duration matters more than placement, or vice versa. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+## How much is explained by calorie intake?
+
+Calorie reduction appears to be a major driver of weight loss in free-living TRE studies. A systematic review and meta-analysis found larger average weight reductions in trials in which participants could eat freely within the window, where reported energy intake also fell more, than in trials in which energy intake was prescribed. Because these were across-study subgroup comparisons and energy intake was often self-reported, the findings are consistent with energy reduction contributing substantially but do not establish why intake fell or quantify how much of the weight loss it caused. ([Chang et al., 2024](https://doi.org/10.1016/j.isci.2024.109000))
+
+In a 12-month RCT of 90 adults with obesity, TRE without calorie counting used a 12:00 to 20:00 window during the first six months and a 10:00 to 20:00 window during the six-month maintenance phase. TRE and daily calorie restriction reduced energy intake and body weight by similar amounts, with no statistically detectable difference between them for weight loss. ([Lin et al., 2023](https://doi.org/10.7326/M23-0052)) In a separate 12-month RCT of 139 adults with obesity, adding an 08:00 to 16:00 window to the same calorie-restricted diet did not significantly improve weight loss, body composition, or metabolic risk factors compared with calorie restriction alone. ([Liu et al., 2022](https://doi.org/10.1056/NEJMoa2114833))
+
+A 12-week controlled-feeding RCT provided all food to 41 adults with obesity and prediabetes or diet-controlled type 2 diabetes. When calories and nutrients were matched, no statistically detectable difference in weight or glycemic outcomes was found between an early ten-hour pattern with 80 percent of calories consumed before 13:00 and a usual eating pattern with at least half of calories consumed after 17:00. ([Maruthur et al., 2024](https://doi.org/10.7326/M23-3132))
+
+The claim that TRE works only when calories fall is still too absolute. In a tightly controlled crossover trial of eight men with prediabetes, five weeks of a weight-maintaining six-hour early window improved insulin sensitivity, beta-cell responsiveness, blood pressure, and the oxidative-stress marker 8-isoprostane compared with a 12-hour schedule. However, the trial was tiny and changed early placement and window duration at the same time. ([Sutton et al., 2018](https://doi.org/10.1016/j.cmet.2018.04.010))
+
+The most defensible conclusion is that reduced calorie intake is likely a major contributor to observed weight loss, while calorie-independent changes in some short-term metabolic markers remain possible but inconsistent. No matched-calorie trial has established an independent long-term reduction in diabetes, cardiovascular events, or mortality. ([Chang et al., 2024](https://doi.org/10.1016/j.isci.2024.109000); [Liu et al., 2022](https://doi.org/10.1056/NEJMoa2114833); [Maruthur et al., 2024](https://doi.org/10.7326/M23-3132); [Sutton et al., 2018](https://doi.org/10.1016/j.cmet.2018.04.010))
+
+## Self-selected versus prescribed windows
+
+The direct evidence does not show that self-selection improves adherence or outcomes. In the 197-participant RCT, adherence was similarly high at 85 to 88 percent across prescribed early, prescribed late, and self-selected eight-hour windows. The three TRE groups also had similar weight loss and no difference in the primary visceral-fat outcome. ([Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y))
+
+A scoping review of 28 studies found median adherence of 89 percent in interventions shorter than 12 weeks and 81 percent in longer interventions, but the ranges were wide. Allowing individual adjustment, providing support, and accommodating daily routines were repeatedly reported as aiding feasibility. Because study definitions and monitoring methods differed, these figures do not prove that one schedule is easier to sustain. ([Termannsen et al., 2023](https://doi.org/10.1002/oby.23743))
+
+Long-term persistence appears weaker once active support ends. In a 12-month follow-up of one site from the Dote-Montero trial, 26 percent reported engaging in TRE during follow-up. Only 65 of the 99 participants in this single-site cohort provided follow-up data, so that estimate is uncertain and should not be treated as a precise long-term adherence rate. ([Camacho-Cardenosa et al., 2026](https://doi.org/10.1016/j.clnu.2026.106706))
+
+Self-selection is therefore a reasonable way to fit TRE around work, sleep, family, and social routines, but it has not been shown to produce better adherence or metabolic outcomes than a prescribed window. ([Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y); [Termannsen et al., 2023](https://doi.org/10.1002/oby.23743))
+
+## Quick reference
+
+* Optimal duration: No specific duration has been established. Four hours was not better than six hours in the main direct comparison, and duration rankings across trials were inconsistent. ([Cienfuegos et al., 2020](https://doi.org/10.1016/j.cmet.2020.06.018); [Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+* Early versus late: Earlier windows perform modestly better in combined network meta-analytic estimates based on sparse direct evidence and indirect comparisons, but recent same-duration direct trials are mixed or null for many outcomes. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071); [Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y); [Peters et al., 2025](https://doi.org/10.1126/scitranslmed.adv6787))
+
+* Duration versus placement: Neither has been shown to matter more because the reviewed evidence lacks a sufficiently powered factorial RCT that separates them. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+* Self-selected versus prescribed: Self-selected windows are feasible, but the best direct RCT found similar adherence and outcomes across schedules. ([Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y))
+
+* Calories: Lower energy intake appears to be a major contributor to TRE-related weight loss. Small controlled studies suggest that some short-term metabolic effects may occur without weight loss, but this is not consistent evidence of independent long-term clinical benefit. ([Chang et al., 2024](https://doi.org/10.1016/j.isci.2024.109000); [Maruthur et al., 2024](https://doi.org/10.7326/M23-3132); [Sutton et al., 2018](https://doi.org/10.1016/j.cmet.2018.04.010))
+
+## Practical interpretation
+
+* An eight- to ten-hour window is a reasonable practical starting range, not a proven biological optimum. It is less restrictive than four- to six-hour schedules, and the evidence has not established that those shorter windows provide greater overall benefit. ([Cienfuegos et al., 2020](https://doi.org/10.1016/j.cmet.2020.06.018); [Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071); [Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y); [Maruthur et al., 2024](https://doi.org/10.7326/M23-3132))
+
+* If two windows are equally sustainable, earlier placement is a reasonable preference because the total evidence modestly favors it. The advantage is not large or consistent enough to justify a schedule that substantially undermines adherence. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071); [Peters et al., 2025](https://doi.org/10.1126/scitranslmed.adv6787); [Termannsen et al., 2023](https://doi.org/10.1002/oby.23743))
+
+* TRE should be understood mainly as a way to structure intake, not as a method that makes calorie balance irrelevant. Whether it helps depends heavily on what happens to total intake and whether the schedule can be maintained. ([Chang et al., 2024](https://doi.org/10.1016/j.isci.2024.109000); [Lin et al., 2023](https://doi.org/10.7326/M23-0052); [Camacho-Cardenosa et al., 2026](https://doi.org/10.1016/j.clnu.2026.106706))
+
+## Funding and conflict-of-interest notes
+
+The main 2026 network meta-analysis was supported by Taiwanese public research funding; the authors reported no relevant financial relationships, and the funders had no role in the work. ([Chen et al., 2026](https://doi.org/10.1136/bmjmed-2024-001071))
+
+The Dote-Montero trial was publicly funded in Spain and the European Union. One coauthor was separately funded through the Intramural Research Program of the US National Institute on Aging. One author reported lecture fees from Novo Nordisk and Abbott for unrelated work. No fasting-program or food-company sponsor was listed in the published funding disclosures. ([Dote-Montero et al., 2025](https://doi.org/10.1038/s41591-024-03375-y))
+
+The Peters trial was funded mainly by German public and scientific organizations, but support included a German Diabetes Association award associated with Abbott. One author reported Novo Nordisk lecture honoraria, and another co-founded a fasting academy and served on a therapeutic-fasting association board. Its largely null result is considered alongside independent trials and is not the sole basis for any conclusion. ([Peters et al., 2025](https://doi.org/10.1126/scitranslmed.adv6787))
+
+The Queiroz trial reported that one author had previously consulted for an intermittent-fasting app. The Cienfuegos trial reported Hachette author fees for K.A. Varady. Neither study is used as the sole support for a favorable claim. ([Queiroz et al., 2023](https://doi.org/10.1017/S0007114522001581); [Cienfuegos et al., 2020](https://doi.org/10.1016/j.cmet.2020.06.018))
+
+## References
+
+* Camacho-Cardenosa A, et al. Effects of an early, late, and self-selected time-restricted eating intervention on weight loss maintenance in adults with overweight or obesity: A 12-month follow-up of a randomized controlled trial. Clin Nutr. 2026;63:106706. [DOI: 10.1016/j.clnu.2026.106706](https://doi.org/10.1016/j.clnu.2026.106706). PMID: 42302513.
+
+* Chang Y, Du T, Zhuang X, Ma G. Time-restricted eating improves health because of energy deficit and circadian rhythm: A systematic review and meta-analysis. iScience. 2024;27:109000. [DOI: 10.1016/j.isci.2024.109000](https://doi.org/10.1016/j.isci.2024.109000). PMID: 38357669.
+
+* Chen YE, Tsai HL, Tu YK, Chen LW. Effects of timing and eating duration of time restricted eating on metabolic outcomes: Systematic review and network meta-analysis. BMJ Med. 2026;5:e001071. [DOI: 10.1136/bmjmed-2024-001071](https://doi.org/10.1136/bmjmed-2024-001071). PMID: 41586347.
+
+* Cienfuegos S, et al. Effects of 4- and 6-h time-restricted feeding on weight and cardiometabolic health: A randomized controlled trial in adults with obesity. Cell Metab. 2020;32(3):366-378.e3. [DOI: 10.1016/j.cmet.2020.06.018](https://doi.org/10.1016/j.cmet.2020.06.018). PMID: 32673591.
+
+* Dote-Montero M, et al. Effects of early, late and self-selected time-restricted eating on visceral adipose tissue and cardiometabolic health in participants with overweight or obesity: A randomized controlled trial. Nat Med. 2025;31:524-533. [DOI: 10.1038/s41591-024-03375-y](https://doi.org/10.1038/s41591-024-03375-y). PMID: 39775037.
+
+* Koppold DA, et al. International consensus on fasting terminology. Cell Metab. 2024;36(8):1779-1794.e4. [DOI: 10.1016/j.cmet.2024.06.013](https://doi.org/10.1016/j.cmet.2024.06.013). PMID: 39059384.
+
+* Lin S, et al. Time-restricted eating without calorie counting for weight loss in a racially diverse population: A randomized controlled trial. Ann Intern Med. 2023;176(7):885-895. [DOI: 10.7326/M23-0052](https://doi.org/10.7326/M23-0052). PMID: 37364268.
+
+* Liu D, et al. Calorie restriction with or without time-restricted eating in weight loss. N Engl J Med. 2022;386(16):1495-1504. [DOI: 10.1056/NEJMoa2114833](https://doi.org/10.1056/NEJMoa2114833). PMID: 35443107.
+
+* Maruthur NM, et al. Effect of isocaloric, time-restricted eating on body weight in adults with obesity: A randomized controlled trial. Ann Intern Med. 2024;177(5):549-558. [DOI: 10.7326/M23-3132](https://doi.org/10.7326/M23-3132). PMID: 38639542.
+
+* Peters B, et al. Intended isocaloric time-restricted eating shifts circadian clocks but does not improve cardiometabolic health in women with overweight. Sci Transl Med. 2025;17(822):eadv6787. [DOI: 10.1126/scitranslmed.adv6787](https://doi.org/10.1126/scitranslmed.adv6787). PMID: 41160666.
+
+* Queiroz JDN, et al. Cardiometabolic effects of early v. delayed time-restricted eating plus energetic restriction in adults with overweight and obesity: An exploratory randomised clinical trial. Br J Nutr. 2023;129(4):637-649. [DOI: 10.1017/S0007114522001581](https://doi.org/10.1017/S0007114522001581). PMID: 35614845.
+
+* Sutton EF, et al. Early time-restricted feeding improves insulin sensitivity, blood pressure, and oxidative stress even without weight loss in men with prediabetes. Cell Metab. 2018;27(6):1212-1221.e3. [DOI: 10.1016/j.cmet.2018.04.010](https://doi.org/10.1016/j.cmet.2018.04.010). PMID: 29754952.
+
+* Termannsen AD, et al. Feasibility of time-restricted eating in individuals with overweight, obesity, prediabetes, or type 2 diabetes: A systematic scoping review. Obesity. 2023;31(6):1463-1485. [DOI: 10.1002/oby.23743](https://doi.org/10.1002/oby.23743). PMID: 37203334.
+
+* Tinsley GM, Heymsfield SB. Fundamental body composition principles provide context for fat-free and skeletal muscle loss with GLP-1 RA treatments. J Endocr Soc. 2024;8(11):bvae164. [DOI: 10.1210/jendso/bvae164](https://doi.org/10.1210/jendso/bvae164). PMID: 39372917.

--- a/pharmacology/GLP-1/do-you-have-to-take-glp-1s-forever.md
+++ b/pharmacology/GLP-1/do-you-have-to-take-glp-1s-forever.md
@@ -1,0 +1,209 @@
+# Do You Have to Take GLP-1s Forever?
+
+The best-supported answer is: not necessarily for every person, but anyone beginning GLP-1-based treatment for obesity should understand that some form of long-term treatment may be needed to preserve most of the weight loss.
+
+Randomized withdrawal trials consistently show substantial average weight regain when semaglutide or tirzepatide is replaced with placebo. This has occurred even when participants continued receiving diet and physical activity counseling. However, no trial proves that every individual must remain on the same medication or the same dose for life, and the evidence does not show that everyone regains all the weight they lost. ([Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+Semaglutide is a GLP-1 receptor agonist. Tirzepatide is technically a dual GIP and GLP-1 receptor agonist. Because the same long-term-treatment question is commonly asked about both, they are discussed here as GLP-1-based obesity medications. The major withdrawal trials discussed below primarily enrolled adults with overweight or obesity without diabetes, so their results should not automatically be applied to the glycemic consequences of stopping treatment in people with diabetes. ([Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+## What "forever" does and does not mean
+
+Three different questions are often compressed into the word "forever":
+
+1. Must everyone stay on the same maximum dose for life?
+
+2. Will many patients need some continued pharmacological support?
+
+3. Can some patients stop and maintain a clinically meaningful amount of weight loss?
+
+
+The current evidence does not support the first claim. Newer trials show that reducing the dose or switching to another medication can preserve more weight loss than stopping pharmacotherapy completely. The evidence is more supportive of the second claim: on average, continued treatment maintains substantially more weight loss than withdrawal. The third possibility clearly exists at an individual level, but there is not yet a validated method for predicting who can stop successfully. ([Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2); [Aronne et al., 2026](https://doi.org/10.1038/s41591-026-04386-7))
+
+The randomized withdrawal trials used enriched designs. Participants were randomized only after completing an open-label treatment period and, in most cases, tolerating the target or maximum tolerated dose. Their results therefore provide strong evidence about continuation versus withdrawal among treatment completers, but the exact regain estimates should not automatically be generalized to every person who begins therapy, including early nonresponders or people who cannot tolerate higher doses. ([Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945); [Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2))
+
+## What happens after stopping semaglutide
+
+In the STEP 1 extension, participants receiving semaglutide 2.4 mg lost an average of 17.3 percent of their starting weight during 68 weeks of treatment. After semaglutide and the trial's structured lifestyle intervention were stopped, they regained an average of 11.6 percentage points over the following year. This represented approximately two-thirds of their previous weight loss. They nevertheless remained an average of 5.6 percent below their original weight at week 120, so the result was substantial regain rather than universal or complete regain. Cardiometabolic improvements also moved back toward baseline. ([Wilding et al., 2022](https://doi.org/10.1111/dom.14725))
+
+The STEP 1 extension did not provide active lifestyle support during the off-treatment year. It was also an exploratory extension conducted in a selected subset of STEP 1 participants rather than a new randomized comparison of different discontinuation strategies. ([Wilding et al., 2022](https://doi.org/10.1111/dom.14725))
+
+STEP 4 provides stronger randomized evidence. After everyone received semaglutide for a 20-week run-in and lost an average of 10.6 percent, participants were randomized either to continue semaglutide or switch to placebo for another 48 weeks. Those continuing semaglutide lost another 7.9 percent, while those switched to placebo gained 6.9 percent relative to their week-20 weight. Both groups continued lifestyle counseling that included a recommended 500 kcal daily energy deficit and at least 150 minutes of physical activity per week. ([Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224))
+
+**Funding context:** STEP 1 and STEP 4 were funded by Novo Nordisk, the manufacturer of semaglutide. In STEP 4, the sponsor was involved in study design and conduct, data collection and analysis, and manuscript preparation, and several authors were company employees or had financial relationships with the company. The randomized findings remain important, but their manufacturer funding makes independent synthesis and replication especially relevant. ([Wilding et al., 2022](https://doi.org/10.1111/dom.14725); [Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224))
+
+## What happens after stopping tirzepatide
+
+In SURMOUNT-4, participants lost an average of 20.9 percent during 36 weeks of open-label tirzepatide treatment. They were then randomized either to continue tirzepatide or switch to placebo for another 52 weeks. Those continuing tirzepatide lost a further 5.5 percent, while those switched to placebo gained 14.0 percent relative to their week-36 weight. By week 88, the continuation group was an average of 25.3 percent below its original weight, while the withdrawal group remained 9.9 percent below baseline. ([Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+Among those continuing tirzepatide, 89.5 percent maintained at least 80 percent of the weight they had initially lost. Only 16.6 percent of those switched to placebo did so. All participants continued receiving lifestyle counseling based on a recommended 500 kcal daily deficit and at least 150 minutes of physical activity per week. The trial therefore directly contradicts the blanket claim that the major withdrawal findings occurred only because lifestyle support disappeared. ([Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+**Funding context:** SURMOUNT-4 was funded by Eli Lilly, the manufacturer of tirzepatide. The sponsor participated in study design, data collection, analysis, interpretation, and manuscript preparation, and several authors were employees and shareholders. The large randomized difference is consistent with semaglutide withdrawal and later systematic reviews, but the precise effect estimate still comes from a manufacturer-sponsored trial. ([Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+## What the systematic reviews add
+
+A 2026 systematic review and meta-analysis included 37 studies, 63 treatment groups, and 9,341 participants who had stopped weight-management medications. Across all medications, weight returned at an average rate of approximately 0.4 kg per month. In analyses of semaglutide and tirzepatide, regain was approximately 0.8 kg per month, with a modeled average of 9.9 kg regained during the first year. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304))
+
+The West analysis projected that people stopping semaglutide or tirzepatide would return to baseline weight after approximately 1.5 years. That result is a model projection, not a directly observed finding. The review had no post-treatment data beyond 52 weeks for the newer medications, and average follow-up across the entire review was only 32 weeks. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304))
+
+A second 2026 systematic review used a nonlinear model that allowed regain to slow over time. It included 48 relevant studies, with six randomized trials and 3,236 participants contributing to the nonlinear model. It estimated that approximately 60 percent of the weight lost during treatment was regained by one year. Beyond 52 weeks, its model projected that regain would eventually plateau at approximately 75.3 percent of the previous loss rather than returning completely to baseline. ([Budini et al., 2026](https://doi.org/10.1016/j.eclinm.2026.103796))
+
+The two reviews therefore agree on the most secure conclusion: substantial regain is common during the first year after stopping. Their longer-term projections differ because they used different trajectory models, not because either review directly observed the eventual endpoint. It is not currently established that everyone returns fully to baseline, nor is it established that regain reliably plateaus with one-quarter of the loss preserved. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304); [Budini et al., 2026](https://doi.org/10.1016/j.eclinm.2026.103796))
+
+**Funding context:** The West review was partly funded by the UK National Institute for Health and Care Research. One author received, and two were partly funded by, a research grant from the Novo Nordisk Foundation. The Budini review reported no funding. These analyses were conducted independently of the pivotal trial sponsors, but they still depend heavily on underlying trials that were largely manufacturer-funded. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304); [Budini et al., 2026](https://doi.org/10.1016/j.eclinm.2026.103796))
+
+## Does structured lifestyle support prevent regain?
+
+The claim that all withdrawal studies removed lifestyle support is incorrect.
+
+In STEP 1, structured support ended when semaglutide ended. In STEP 4 and SURMOUNT-4, diet and activity counseling continued after participants were switched to placebo. Regain still occurred. Standard lifestyle counseling therefore did not fully replace the weight-maintenance effect of continued medication in those trials. ([Wilding et al., 2022](https://doi.org/10.1111/dom.14725); [Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+That does not prove that a more intensive transition program would be ineffective. The counseling in STEP 4 and SURMOUNT-4 was not the same as a closely supervised exercise program, intensive behavioral therapy, or a lifestyle intervention specifically designed for medication withdrawal.
+
+The strongest indication that exercise may help comes from a Danish trial involving liraglutide rather than semaglutide or tirzepatide. After an initial low-calorie diet, participants received one year of supervised exercise, liraglutide, both, or placebo. All active treatment was then stopped. From randomization to one year after treatment ended, the adjusted between-group difference in body-weight change was 5.1 kg in favor of the previous exercise-plus-liraglutide group compared with the previous liraglutide-only group. The adjusted difference in body-fat change was 2.3 percentage points in favor of the combination group. Regain during the off-treatment year was also 6.0 kg greater after liraglutide alone than after supervised exercise alone. ([Jensen et al., 2024](https://doi.org/10.1016/j.eclinm.2024.102475))
+
+This is promising but not definitive. Only 109 participants attended the post-treatment assessment, the off-treatment period was not separately randomized, and the medication was liraglutide, which generally produces less weight loss than the semaglutide and tirzepatide regimens examined in the major modern obesity trials. The study was funded by Helsefonden and the Novo Nordisk Foundation. ([Jensen et al., 2024](https://doi.org/10.1016/j.eclinm.2024.102475); [Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+The West meta-analysis did not detect a clear association between the intensity of behavioral support and the rate of regain. However, only two studies provided meaningfully different behavioral support after treatment ended. This is an absence of convincing evidence, not evidence that intensive post-treatment support cannot help. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304))
+
+## Does regain prove GLP-1s do not address the root causes?
+
+The withdrawal trials do not define or measure a single "root cause" of obesity. They test whether the achieved weight reduction persists when treatment is withdrawn.
+
+The observed regain shows that much of the average treatment effect is dependent on continuing pharmacological treatment. It does not prove that the medication was ineffective, just as continued efficacy while taking a medication does not prove that the underlying susceptibility has been permanently removed.
+
+The opposite claim, that stopping leaves no residual benefit at one year, is also too strong. Participants who stopped semaglutide in the STEP 1 extension remained an average of 5.6 percent below baseline after one year. Participants who stopped tirzepatide in SURMOUNT-4 remained an average of 9.9 percent below baseline after one year, although most had regained a large portion of their previous loss. ([Wilding et al., 2022](https://doi.org/10.1111/dom.14725); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+The most accurate conclusion is that GLP-1-based medications usually control weight more effectively while treatment continues than after it is withdrawn. The trials do not establish whether that should be described philosophically as treating symptoms, modifying causes, or both.
+
+## Can GLP-1s be used as a temporary bridge?
+
+A temporary bridge may be possible for some individuals, but it is not yet an evidence-based default strategy.
+
+To establish the bridge model properly, participants would need to receive medication together with an intensive lifestyle program, reach a predefined maintenance phase, undergo a structured withdrawal strategy, and then be followed drug-free for several years. That strategy would need to be compared with continued medication and with ordinary lifestyle counseling. No such trial has yet established that habits developed during treatment can reliably preserve most semaglutide- or tirzepatide-induced weight loss after the medication is removed. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304))
+
+The liraglutide exercise study suggests that supervised exercise during treatment may improve later maintenance, but it does not show that most patients can use semaglutide or tirzepatide temporarily and then maintain the full result through lifestyle alone. ([Jensen et al., 2024](https://doi.org/10.1016/j.eclinm.2024.102475))
+
+A more defensible use of the word "bridge" may be a bridge from an intensive weight-loss dose to a lower maintenance dose or to another form of pharmacotherapy, rather than necessarily a bridge to no medication.
+
+## Long-term treatment may not require the same maximum dose
+
+SURMOUNT-MAINTAIN directly tested dose reduction. Participants first received tirzepatide at a maximum tolerated dose of 10 or 15 mg for 60 weeks. The 378 participants who lost at least 5 percent and tolerated at least 10 mg were then randomized for another 52 weeks to continue the maximum tolerated dose, reduce to 5 mg, or switch to placebo. All groups continued receiving lifestyle counseling. ([Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2))
+
+At week 112, the model-based estimated change in weight from original baseline was -21.9 percent in the maximum-dose group, -16.6 percent in the 5 mg group, and -9.9 percent in the placebo group. Rescue tirzepatide was permitted when participants regained more than half of their previous loss and was used by approximately 8 percent of the maximum-dose group, 25 percent of the 5 mg group, and 67 percent of the placebo group. Under the primary modified treatment-regimen estimand, measurements obtained after rescue tirzepatide or a weight-loss procedure were excluded, and the worst observed value before that intervention was carried forward. The placebo estimate therefore does not represent the observed average result of leaving every placebo-assigned participant untreated for a full year. ([Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2))
+
+This trial provides evidence that a lower dose can preserve more weight loss than complete withdrawal, although it did not maintain as much as the maximum tolerated dose. It was a reduced-dose maintenance trial, not a gradual taper-to-zero trial.
+
+**Funding context:** SURMOUNT-MAINTAIN was funded by Eli Lilly. The sponsor was involved in study design, data collection, analysis, interpretation, and drafting, and multiple authors were company employees or shareholders. Independent replication would strengthen confidence in reduced-dose maintenance. ([Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2))
+
+## Switching medication is not the same as stopping
+
+ATTAIN-MAINTAIN tested whether participants could switch from injectable semaglutide or tirzepatide to daily oral orforglipron, another GLP-1 receptor agonist. Eligible participants had completed 72 weeks of injectable treatment, lost at least 5 percent of their starting weight, and were randomized to orforglipron or placebo for 52 weeks. ([Aronne et al., 2026](https://doi.org/10.1038/s41591-026-04386-7))
+
+Among participants whose weight had plateaued after tirzepatide, orforglipron preserved an estimated 74.7 percent of the prior weight reduction, compared with 49.2 percent with placebo. After semaglutide, the corresponding values were 79.3 percent and 37.6 percent. However, participants assigned to placebo could receive rescue orforglipron after regaining at least half of their previous loss. Rescue orforglipron was used by 39 of 80 placebo-assigned participants, or 48.8 percent, in the prior-tirzepatide cohort and by 42 of 66, or 63.6 percent, in the prior-semaglutide cohort. At week 52, only 25 of 80 and 12 of 66 placebo-assigned participants, respectively, had completed treatment without receiving rescue or another active obesity medication. ([Aronne et al., 2026](https://doi.org/10.1038/s41591-026-04386-7))
+
+Because rescue treatment was available from week 24 and was common, the reported 52-week comparisons are estimand-based trial estimates rather than fully observed, uninterrupted year-long drug-free trajectories in the placebo groups. The trial supports switching to continued oral pharmacotherapy. It does not show that the medication effect can be maintained after all pharmacological treatment ends. ([Aronne et al., 2026](https://doi.org/10.1038/s41591-026-04386-7))
+
+**Funding context:** ATTAIN-MAINTAIN was funded by Eli Lilly. The company participated in design, data collection, analysis, interpretation, and writing. Eight authors were Eli Lilly employees and shareholders, while several other authors reported relationships with Eli Lilly, Novo Nordisk, or other pharmaceutical companies. ([Aronne et al., 2026](https://doi.org/10.1038/s41591-026-04386-7))
+
+## Does gradual tapering prevent regain?
+
+There is currently no randomized trial showing that gradually tapering semaglutide or tirzepatide all the way to zero prevents more long-term weight regain than stopping abruptly.
+
+A 2025 Expert Opinion article proposed an example semaglutide schedule in which 2.4 mg is reduced to 1.7 mg for 4 to 6 weeks, followed by 1.0 mg, 0.5 mg, and eventual discontinuation only if weight and appetite remain stable. The authors explicitly described this approach as based on clinical experience, anecdotal, speculative, and unsupported by randomized trials. It should therefore be understood as a research hypothesis, not a validated tapering protocol. ([Brufani and Morviducci, 2025](https://doi.org/10.1093/obendo/wjaf011))
+
+The article reported no funding or conflicts of interest. Its clinical registry contained only 76 patients, and it did not provide a randomized comparison of gradual tapering against abrupt withdrawal. ([Brufani and Morviducci, 2025](https://doi.org/10.1093/obendo/wjaf011))
+
+A taper may make a transition feel more manageable or allow clinicians to identify whether a lower dose remains effective, but it has not been shown to create a durable physiological advantage after the drug has completely cleared. Reduced-dose maintenance and tapering to discontinuation are different strategies and should not be treated as equivalent.
+
+## Predictors of successful maintenance after stopping
+
+No validated clinical prediction rule currently identifies which patients can discontinue GLP-1-based medication and maintain most of their weight loss.
+
+A 2026 retrospective analysis examined 4,182 patients during the six months after their last semaglutide or tirzepatide prescription recorded in participating health systems. Approximately two-thirds did not gain at least 2 percent during that short period. Among a subset of 119 patients whose clinical notes specifically documented discontinuation, 72 percent did not meet the study's definition of regain. Exercise counseling was documented more frequently among those without regain than among those with regain, at 26.2 percent versus 14.7 percent. ([Murugadoss et al., 2026](https://doi.org/10.1093/biomethods/bpag020))
+
+These results should be interpreted cautiously. A last prescription in one health system did not prove that medication exposure had ended, and the authors acknowledged that some patients could have obtained medication through other clinicians, telehealth providers, medical spas, or compounding pharmacies. Follow-up lasted only six months, most participants had diabetes, counseling was not randomized, and weight trajectories were already beginning to turn upward near the end of follow-up. Restarts and other weight-management treatments could also have been incompletely captured. ([Murugadoss et al., 2026](https://doi.org/10.1093/biomethods/bpag020))
+
+The study suggests that weight regain of at least 2 percent within six months after the last recorded prescription was not universal in this selected EHR population. It does not establish six-month outcomes after confirmed complete discontinuation because continued exposure, outside prescribing, restarts, and other treatments could not be comprehensively captured. It also does not establish exercise counseling as a causal predictor or overturn the longer randomized withdrawal trials. ([Murugadoss et al., 2026](https://doi.org/10.1093/biomethods/bpag020))
+
+**Conflict context:** The study reported no funding, but four authors were employees of nference, a company with research collaborations involving Eli Lilly, Novo Nordisk, and AstraZeneca. The authors stated that those companies did not fund or participate in the study. ([Murugadoss et al., 2026](https://doi.org/10.1093/biomethods/bpag020))
+
+At present, supervised exercise is a promising modifiable strategy, but not a validated predictor. No validated clinical prediction rule emerged from the evidence reviewed. Proposed behavioral or clinical factors, including initial weight loss, starting weight, or apparent stability on treatment, remain exploratory and have not been shown to identify reliably who will maintain most of the loss for several years after complete discontinuation. ([Jensen et al., 2024](https://doi.org/10.1016/j.eclinm.2024.102475); [Murugadoss et al., 2026](https://doi.org/10.1093/biomethods/bpag020); [West et al., 2026](https://doi.org/10.1136/bmj-2025-085304))
+
+## Main evidence gaps
+
+The most important unanswered questions are:
+
+- What happens after more than one year of confirmed drug-free follow-up after modern-dose semaglutide or tirzepatide?
+
+- Does gradual tapering to zero produce better outcomes than abrupt withdrawal?
+
+- Can intensive supervised exercise and behavioral treatment materially reduce regain after semaglutide or tirzepatide is stopped?
+
+- Which clinical, behavioral, or biological characteristics predict successful discontinuation?
+
+- Does preserving part of the weight loss after discontinuation preserve meaningful long-term cardiovascular or metabolic benefits?
+
+- Can reduced-dose maintenance provide similar long-term clinical benefits with lower cost, fewer adverse effects, or better adherence?
+
+
+The available systematic reviews identify substantial first-year regain clearly, but longer-term trajectories and successful discontinuation strategies remain limited by short follow-up, heterogeneous interventions, and extrapolation beyond observed data. ([West et al., 2026](https://doi.org/10.1136/bmj-2025-085304); [Budini et al., 2026](https://doi.org/10.1016/j.eclinm.2026.103796))
+
+## Quick reference
+
+- **STEP 1 extension:** Approximately two-thirds of semaglutide-induced weight loss was regained during the first year after semaglutide and structured lifestyle support stopped. Average weight remained 5.6 percent below baseline. ([Wilding et al., 2022](https://doi.org/10.1111/dom.14725))
+
+- **STEP 4:** Switching from semaglutide to placebo produced a 6.9 percent weight increase over 48 weeks despite continued lifestyle counseling. ([Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224))
+
+- **SURMOUNT-4:** Switching from tirzepatide to placebo produced a 14.0 percent weight increase over 52 weeks despite continued lifestyle counseling. ([Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+- **SURMOUNT-MAINTAIN:** Reducing tirzepatide to 5 mg preserved more weight loss than switching to placebo, but it remained ongoing medication. The week-112 results were model-based estimates, and rescue tirzepatide was common in the placebo group. ([Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2))
+
+- **Supervised exercise:** A liraglutide trial suggests that supervised exercise during treatment may improve post-treatment maintenance, but equivalent evidence is not yet available for semaglutide or tirzepatide. ([Jensen et al., 2024](https://doi.org/10.1016/j.eclinm.2024.102475))
+
+- **Tapering to zero:** No randomized trial has established that gradual tapering prevents long-term regain. ([Brufani and Morviducci, 2025](https://doi.org/10.1093/obendo/wjaf011))
+
+- **Predicting success:** Individual variation is real, but there is no validated tool that can determine in advance who will maintain most of the loss after stopping. ([Murugadoss et al., 2026](https://doi.org/10.1093/biomethods/bpag020))
+
+
+## Practical interpretation
+
+- GLP-1-based treatment should not automatically be described as lifelong for every person. It should be started with an honest expectation that ongoing treatment may be necessary.
+
+- Long-term treatment does not necessarily mean remaining on the original maximum dose forever. Lower-dose maintenance and switching to another medication now have randomized evidence, although the relevant trials were manufacturer-funded and would benefit from independent replication. ([Horn et al., 2026](https://doi.org/10.1016/S0140-6736%2826%2900656-2); [Aronne et al., 2026](https://doi.org/10.1038/s41591-026-04386-7))
+
+- Lifestyle support remains important, including regular exercise, appropriate nutrition, and behavioral strategies, but no specific lifestyle intervention, including resistance training, should currently be promised as a proven substitute for the medication's weight-maintenance effect after withdrawal. ([Jensen et al., 2024](https://doi.org/10.1016/j.eclinm.2024.102475); [West et al., 2026](https://doi.org/10.1136/bmj-2025-085304))
+
+- A discontinuation attempt should be planned with the prescriber, with monitoring and a predefined response if substantial hunger, weight regain, or deterioration in relevant metabolic measures occurs. The exact tapering schedule and restart thresholds remain unvalidated. ([Brufani and Morviducci, 2025](https://doi.org/10.1093/obendo/wjaf011))
+
+- People using these medications for diabetes require a separate clinical discontinuation plan because the principal obesity withdrawal trials were conducted largely in people without diabetes. ([Rubino et al., 2021](https://doi.org/10.1001/jama.2021.3224); [Aronne et al., 2024](https://doi.org/10.1001/jama.2023.24945))
+
+
+## Bottom line
+
+GLP-1-based obesity medications do not have to be declared lifelong for every patient. However, the best available evidence supports treating them as potentially long-term therapies rather than assuming that a temporary course will usually produce permanent weight loss.
+
+Substantial regain is common after semaglutide or tirzepatide is stopped, including in randomized trials where lifestyle counseling continued. This does not mean that everyone regains everything, and it does not prove anything definitive about an undefined "root cause." It shows that much of the average weight-maintenance effect depends on continued treatment.
+
+There is now randomized evidence for reducing tirzepatide to a lower ongoing dose and for switching from injectable treatment to another GLP-1 medication. These strategies still involve ongoing pharmacotherapy, and the 2026 trials used rescue treatment and model-based estimands that complicate interpretation of the placebo groups. There is still no randomized evidence that tapering all the way to zero prevents regain. Intensive supervised exercise is promising, but the evidence is not yet strong enough to guarantee successful medication-free maintenance.
+
+## References
+
+- Wilding JPH, Batterham RL, Davies M, et al. [Weight regain and cardiometabolic effects after withdrawal of semaglutide: the STEP 1 trial extension](https://doi.org/10.1111/dom.14725). _Diabetes Obes Metab._ 2022;24(8):1553-1564. DOI: 10.1111/dom.14725. PMID: 35441470.
+
+- Rubino D, Abrahamsson N, Davies M, et al. [Effect of continued weekly subcutaneous semaglutide vs placebo on weight loss maintenance in adults with overweight or obesity: the STEP 4 randomized clinical trial](https://doi.org/10.1001/jama.2021.3224). _JAMA._ 2021;325(14):1414-1425. DOI: 10.1001/jama.2021.3224. PMID: 33755728.
+
+- Aronne LJ, Sattar N, Horn DB, et al. [Continued treatment with tirzepatide for maintenance of weight reduction in adults with obesity: the SURMOUNT-4 randomized clinical trial](https://doi.org/10.1001/jama.2023.24945). _JAMA._ 2024;331(1):38-48. DOI: 10.1001/jama.2023.24945. PMID: 38078870.
+
+- Horn DB, Aronne LJ, Wharton S, et al. [Tirzepatide for maintenance of bodyweight reduction in people with obesity in the USA (SURMOUNT-MAINTAIN): a multicentre, double-blind, randomised, placebo-controlled trial](https://doi.org/10.1016/S0140-6736%2826%2900656-2). _Lancet._ 2026;407(10545):2305-2318. DOI: 10.1016/S0140-6736(26)00656-2. PMID: 42119587.
+
+- Aronne LJ, Horn DB, le Roux CW, et al. [Orforglipron for maintenance of body weight reduction: the double-blind, randomized phase 3b ATTAIN-MAINTAIN trial](https://doi.org/10.1038/s41591-026-04386-7). _Nat Med._ 2026;32:2679-2687. DOI: 10.1038/s41591-026-04386-7. PMID: 42120723.
+
+- West S, Scragg J, Aveyard P, et al. [Weight regain after cessation of medication for weight management: systematic review and meta-analysis](https://doi.org/10.1136/bmj-2025-085304). _BMJ._ 2026;392:e085304. DOI: 10.1136/bmj-2025-085304. PMID: 41500720.
+
+- Budini B, Luo S, Tam MGZ, et al. [Trajectory of weight regain after cessation of GLP-1 receptor agonists: a systematic review and nonlinear meta-regression](https://doi.org/10.1016/j.eclinm.2026.103796). _EClinicalMedicine._ 2026;93:103796. DOI: 10.1016/j.eclinm.2026.103796. PMID: 41938838.
+
+- Jensen SBK, Blond MB, Sandsdal RM, et al. [Healthy weight loss maintenance with exercise, GLP-1 receptor agonist, or both combined followed by one year without treatment: a post-treatment analysis of a randomised placebo-controlled trial](https://doi.org/10.1016/j.eclinm.2024.102475). _EClinicalMedicine._ 2024;69:102475. DOI: 10.1016/j.eclinm.2024.102475. PMID: 38544798.
+
+- Murugadoss K, Varma G, Venkatakrishnan AJ, Gibson CM, Soundararajan V. [Weight trajectories after last tirzepatide or semaglutide prescription across a federated health network](https://doi.org/10.1093/biomethods/bpag020). _Biol Methods Protoc._ 2026;11(1):bpag020. DOI: 10.1093/biomethods/bpag020.
+
+- Brufani C, Morviducci L. [Semaglutide in a real-world outpatient setting: discontinuation patterns and weight maintenance](https://doi.org/10.1093/obendo/wjaf011). _Obes Endocrinol._ 2025;1(2):wjaf011. DOI: 10.1093/obendo/wjaf011.


### PR DESCRIPTION
## Summary

- Add a chrononutrition hub with evidence reviews on dinner timing and daily eating windows.
- Add an evidence review on long-term GLP-1-based obesity treatment and withdrawal.
- Use canonical source links and document study limitations and funding contexts.

## Validation

- Confirmed all relative links resolve.
- Confirmed non-DOI external sources return successful responses.
- Verified 42 unique linked citations under the contributor tracking rules.