### PR TITLE
Handle WHOOP bot-blocked links in link checks

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -109,6 +109,7 @@ jobs:
             --exclude "^https://insight\\.jci\\.org/"
             --exclude "^https://shop\\.fittr\\.care/products/fittr-hart-ring$"
             --exclude "^https://www\\.asep\\.org/"
+            --exclude "^https://www\\.whoop\\.com/"
             --exclude "^https://support\\.whoop\\.com/"
             --timeout 30
             '**/*.md'


### PR DESCRIPTION
## Summary

- Exclude www.whoop.com from link checks because the site returns 403 to the GitHub runner while the page remains publicly available.
- Leave the linked content unchanged and preserve checks for all other domains.

## Validation

- Confirmed the current run reports one error: the WHOOP URL.
- Confirmed the scheduled run reports the same URL.